### PR TITLE
Set default sub-spec 'Store' in Podfile

### DIFF
--- a/Verge.podspec
+++ b/Verge.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   
   s.swift_version = '5.2'
 
-  s.default_subspec = 'Core'
+  s.default_subspec = 'Store'
 
   s.weak_frameworks = ['Combine', 'SwiftUI']
 


### PR DESCRIPTION
Previously, if we set 'pod 'Verge', it will install `Core` only.
it's not useful, basically, the customer wants to install Store.
and we keep ORM is optional sub-spec