### PR TITLE
Add option to select a RecursiveLock on Storage

### DIFF
--- a/Sources/VergeStore/Store/Store.swift
+++ b/Sources/VergeStore/Store/Store.swift
@@ -118,7 +118,30 @@ open class Store<State, Activity>: _VergeObservableObjectBase, CustomReflectable
     logger: StoreLogger?
   ) {
 
-    self._backingStorage = .init(.init(old: nil, new: initialState))
+    self._backingStorage = .init(
+      .init(old: nil, new: initialState),
+      recursiveLock: NSRecursiveLock()
+    )
+    self.logger = logger
+
+    super.init()
+
+    sinkCancellable = sinkState { [weak self] state in
+      self?.receive(state: state)
+    }
+
+  }
+
+  public init<RecursiveLock: _VergeRecursiveLockType>(
+    initialState: State,
+    backingStorageRecursiveLock: RecursiveLock,
+    logger: StoreLogger?
+  ) {
+
+    self._backingStorage = .init(
+      .init(old: nil, new: initialState),
+      recursiveLock: backingStorageRecursiveLock
+    )
     self.logger = logger
 
     super.init()


### PR DESCRIPTION
Until now, `Storage` that used inside `Store` implicitly uses `NSRecursiveLock` to update the value thread safely.

This PR enables us to select a recursive-lock that we want to use.

`VergeAnyRecursiveLock` is type-erased type of recursive-lock.

`VergeNoLock` is pretended as recursive-lock, actually, it does nothing.
This would be useful to tune performance when Store is used only on main-thread. (Basically locking will take a bit cost.)


To create a Store that uses `VergeNoLock`

```swift

Store<MyState, MyActivity>.init(initialState: ..., backingStorageRecursiveLock: VergeNoLock(), logger: nil)
```