### PR TITLE
Fragment updates to Edge with middleware

### DIFF
--- a/Docs/docs/VergeStore/utilities.md
+++ b/Docs/docs/VergeStore/utilities.md
@@ -39,6 +39,31 @@ appState.yourState.name
 appState.$yourState.version
 ```
 
+### Edge can validate the value and modify to be correctly
+
+Edge supports a concept of middleware that catch a new value and modifiable.  
+Please check `Edge.Middleware` to see more detail.
+
+```swift
+let middleware = Edge<Value>.Middleware.init(onSet: { value in /* do something */ })
+```
+
+To set it up, we can declare as followings:
+
+```swift
+@Edge(middleware: .assert { $0 >= 0 }) var count = 0
+```
+
+It can be combined from multiple middleware.
+
+```swift
+@Edge(middleware: .init([
+  .assert { $0 >= 0 },
+  .init { value in /* performs something */ },
+]))
+var count = 0
+```
+
 ## assign - assignee
 
 In specific cases, it needs to projects value from others into the Store.

--- a/Docs/docs/VergeStore/utilities.md
+++ b/Docs/docs/VergeStore/utilities.md
@@ -4,9 +4,9 @@ title: Utilities
 sidebar_label: Utilities
 ---
 
-## `Fragment<State>`
+## `Edge<State>`
 
-### Fragment helps compare if state was updated without Equatable
+### Edge helps compare if state was updated without Equatable
 
 ‌In a single state tree, comparing for reducing the number of updates would be most important for keep performance. However, implementing Equatable is not easy basically. Instead, adding a like flag that indicates updated itself, it would be easy
 
@@ -14,11 +14,11 @@ sidebar_label: Utilities
 
 Actually, we need to get to flag that means **different**, it no need to be **equal**.
 
-### Fragment does embed state with versioning
+### Edge does embed state with versioning
 
-`Fragment` manages the version of itself, the version will increment each modification. however, it can't get how exactly modified from the modification. and Fragment returns equality by comparing their version.
-That is the reason why Fragment may return boolean that false negative.
-If Fragment returns equality false, it may be actually equals.
+`Edge` manages the version of itself, the version will increment each modification. however, it can't get how exactly modified from the modification. and Edge returns equality by comparing their version.
+That is the reason why Edge may return boolean that false positive.
+If Edge returns equality false, it may be actually equals.
 
 ```swift
 struct YourState {
@@ -27,10 +27,10 @@ struct YourState {
 
 struct AppState: Equatable {
 
-  @Fragment var yourState YourState = .init()
+  @Edge var yourState YourState = .init()
 }
 
-> Since `Fragment` enables `Equatable` in yourState, AppState can be Equatable with synthesizing.
+> Since `Edge` enables `Equatable` in yourState, AppState can be Equatable with synthesizing.
 
 appState.yourState.name
 

--- a/Sources/VergeStore/Edge.swift
+++ b/Sources/VergeStore/Edge.swift
@@ -41,7 +41,7 @@ public protocol EdgeType : Equatable {
  To get this done, it's not always we need to support Equatable.
  It's easier to detect the difference than detect equals.
 
- Fragment is a wrapper structure and manages version number inside.
+ Edge is a wrapper structure and manages version number inside.
  It increments the version number each wrapped value updated.
 
  Memoization can use that version if it should pass new input.
@@ -116,7 +116,7 @@ extension Edge {
    A handler that can modify a new state.
 
    ```swift
-   @Edge(middleware: .assert { $0 > 0 }) var count: Int = 0
+   @Edge(middleware: .assert { $0 >= 0 }) var count: Int = 0
    ```
    */
   public struct Middleware {

--- a/Sources/VergeStore/MemoizeMap.swift
+++ b/Sources/VergeStore/MemoizeMap.swift
@@ -130,7 +130,7 @@ extension MemoizeMap where Input : ChangesType {
   /// - Parameter map:
   /// - Returns:
   @_disfavoredOverload
-  public static func map(_ map: @escaping (Changes<Input.Value>) -> Fragment<Output>) -> MemoizeMap<Input, Output> {
+  public static func map(_ map: @escaping (Changes<Input.Value>) -> Edge<Output>) -> MemoizeMap<Input, Output> {
             
     return .init(
       makeInitial: {
@@ -156,7 +156,7 @@ extension MemoizeMap where Input : ChangesType {
   /// - Complexity: ✅ Active Memoization with Fragment's version
   /// - Parameter map:
   /// - Returns:
-  public static func map(_ keyPath: KeyPath<Changes<Input.Value>, Fragment<Output>>) -> MemoizeMap<Input, Output> {
+  public static func map(_ keyPath: KeyPath<Changes<Input.Value>, Edge<Output>>) -> MemoizeMap<Input, Output> {
         
     var instance = MemoizeMap.map({ $0[keyPath: keyPath] })
     

--- a/Sources/VergeStore/_COWFragment.swift
+++ b/Sources/VergeStore/_COWFragment.swift
@@ -39,7 +39,7 @@ import Foundation
  `MemoizeMap.map(_ map: @escaping (Changes<Input.Value>) -> Fragment<Output>) -> MemoizeMap<Input, Output>`
  */
 @propertyWrapper
-public struct _COWFragment<State>: FragmentType {
+public struct _COWFragment<State>: EdgeType {
 
   private final class Storage {
 

--- a/Tests/DemoState.swift
+++ b/Tests/DemoState.swift
@@ -23,9 +23,9 @@ struct DemoState: ExtendedStateType, Equatable {
   var count: Int = 0
   var items: [Int] = []
 
-  @Fragment var dictionary: [String : LargeRecord] = [:]
+  @Edge var dictionary: [String : LargeRecord] = [:]
 
-  @Fragment var nonEquatable: NonEquatable = .init()
+  @Edge var nonEquatable: NonEquatable = .init()
   
   struct Extended: ExtendedType {
     

--- a/Tests/VergeStoreTests/VergeStoreTests.swift
+++ b/Tests/VergeStoreTests/VergeStoreTests.swift
@@ -43,9 +43,9 @@ final class VergeStoreTests: XCTestCase {
     var optionalNested: OptionalNestedState?
     var nested: NestedState = .init()
     
-    @Fragment var treeA = TreeA()
-    @Fragment var treeB = TreeB()
-    @Fragment var treeC = TreeC()
+    @Edge var treeA = TreeA()
+    @Edge var treeB = TreeB()
+    @Edge var treeC = TreeC()
     
   }
   

--- a/Verge.xcodeproj/project.pbxproj
+++ b/Verge.xcodeproj/project.pbxproj
@@ -59,7 +59,7 @@
 		4B6B77AE243FA6B300E0C0EA /* FilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B89538423CCE3B1002F95C8 /* FilterTests.swift */; };
 		4B6BF62B23AD7B74001E5361 /* CollectionPerformance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6BF62923AD7B55001E5361 /* CollectionPerformance.swift */; };
 		4B6E361023A7ED1900EB490C /* IndexType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6E360F23A7ED1900EB490C /* IndexType.swift */; };
-		4B6F6F3924521F1E00B6CC3A /* Fragment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF470CC23CC36E8001A1D5D /* Fragment.swift */; };
+		4B6F6F3924521F1E00B6CC3A /* Edge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF470CC23CC36E8001A1D5D /* Edge.swift */; };
 		4B6F6F3A24521F1E00B6CC3A /* NonAtomicVersionCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF470D123CC3A43001A1D5D /* NonAtomicVersionCounter.swift */; };
 		4B6F6F3B24521F2B00B6CC3A /* CounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF470CE23CC3949001A1D5D /* CounterTests.swift */; };
 		4B71CEEE23B14394004520CE /* ActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B71CEED23B14394004520CE /* ActivityTests.swift */; };
@@ -455,7 +455,7 @@
 		4BF2BCD5238A68CE00F70CDA /* ViewModelBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelBase.swift; sourceTree = "<group>"; };
 		4BF2BCD9238A7B6900F70CDA /* EventEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventEmitter.swift; sourceTree = "<group>"; };
 		4BF3C2EA24209324006B1726 /* MultithreadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultithreadingTests.swift; sourceTree = "<group>"; };
-		4BF470CC23CC36E8001A1D5D /* Fragment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fragment.swift; sourceTree = "<group>"; };
+		4BF470CC23CC36E8001A1D5D /* Edge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Edge.swift; sourceTree = "<group>"; };
 		4BF470CE23CC3949001A1D5D /* CounterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterTests.swift; sourceTree = "<group>"; };
 		4BF470D123CC3A43001A1D5D /* NonAtomicVersionCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAtomicVersionCounter.swift; sourceTree = "<group>"; };
 		4BF76680244E1B5300A5EA10 /* Derived.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Derived.swift; sourceTree = "<group>"; };
@@ -738,7 +738,7 @@
 				4B8EB4F823C034A900035B2A /* Comparer.swift */,
 				4BDB78212447934A00675D03 /* StoreWrapperType.swift */,
 				4B1BE8E4244F28050077DB66 /* MemoizeMap.swift */,
-				4BF470CC23CC36E8001A1D5D /* Fragment.swift */,
+				4BF470CC23CC36E8001A1D5D /* Edge.swift */,
 				4BE33C6824875CD800F3F2C6 /* _COWFragment.swift */,
 				4BF470D123CC3A43001A1D5D /* NonAtomicVersionCounter.swift */,
 				4BB1F98B2465ACB900AF5F0C /* TargetQueue.swift */,
@@ -1667,7 +1667,7 @@
 				4B427419236F269C00C302C8 /* Store.swift in Sources */,
 				4B3834DD2482330C008A0B47 /* UseState.swift in Sources */,
 				4B6F6F3A24521F1E00B6CC3A /* NonAtomicVersionCounter.swift in Sources */,
-				4B6F6F3924521F1E00B6CC3A /* Fragment.swift in Sources */,
+				4B6F6F3924521F1E00B6CC3A /* Edge.swift in Sources */,
 				4B1BE8E5244F28050077DB66 /* MemoizeMap.swift in Sources */,
 				4BCBCA8D2381CC2B00F33B15 /* DetachedDispatcher.swift in Sources */,
 				4B3834DF248235AD008A0B47 /* _VergeObservableObjectBase.swift in Sources */,


### PR DESCRIPTION
This PR updates `Fragment` to `Edges` with renaming and then additionally versioning, it gets middleware concept.
That enables developers to modify and validate its value that was set.

```swift
struct MyState {
  @Edge(middleware: .assert { $0 >= 0 }) var count: Int = 0
}

store.commit {
  $0.count = -1 // raises runtime error from assertionFailure
}
```

`Edge<T>.Middleware` is combinable.

```swift

@Edge(middleware: .init([
  .assert { $0 >= 0 },
  .init { ... },
  .init { ... }
]))
var count = 0

```


the original concept of Edge(formally Fragment) is following

```
 A structure that manages sub-state-tree from root-state-tree.

 When you create derived data for this sub-tree, you may need to activate memoization.
 The reason why it needs memoization, the derived data does not need to know if other sub-state-tree updated.
 Better memoization must know owning state-tree has been updated at least.
 To get this done, it's not always we need to support Equatable.
 It's easier to detect the difference than detect equals.

 Edge is a wrapper structure and manages version number inside.
 It increments the version number each wrapped value updated.

 Memoization can use that version if it should pass new input.

 To activate this feature, you can check this method.
 `MemoizeMap.map(_ map: @escaping (Changes<Input.Value>) -> Edge<Output>) -> MemoizeMap<Input, Output>`
```