### PR TITLE
Add global option to enable signpost monitoring

### DIFF
--- a/Docs/docs/VergeStore/optimization-tips.md
+++ b/Docs/docs/VergeStore/optimization-tips.md
@@ -18,9 +18,14 @@ sidebar_label: Optimization Tips
 
 ## 🏎 Performance monitoring
 
-Verge supports `os_sign_post`
-We can check the performance from Xcode Instruments.
-Please enables signpost profiling.
+Verge supports `os_sign_post`  
+We can check the performance from Xcode Instruments.  
+Please add signpost profiling panel in Instruments and enable the flag in your code.
+
+```swift
+// this flag is global variable
+_verge_signpost_enabled = true
+```
 
 ![CleanShot 2020-05-31 at 14 22 16@2x](https://user-images.githubusercontent.com/1888355/83345130-80152c00-a34a-11ea-925a-6c6a609be102.png)
 

--- a/Sources/VergeCore/Signpost.swift
+++ b/Sources/VergeCore/Signpost.swift
@@ -1,5 +1,7 @@
 import os
 
+public var _verge_signpost_enabled = false
+
 @available(iOS 12, macOS 10.14, *)
 @usableFromInline
 enum SignpostConstants {
@@ -18,7 +20,7 @@ enum SignpostConstants {
 @inlinable
 public func vergeSignpostEvent(_ event: StaticString) {
   #if DEBUG
-  if #available(iOS 12, macOS 10.14, *) {
+  if #available(iOS 12, macOS 10.14, *), _verge_signpost_enabled {
     let id = OSSignpostID(log: SignpostConstants.pointOfInterestLog)
     os_signpost(.event, log: SignpostConstants.pointOfInterestLog, name: event, signpostID: id)
   }
@@ -28,7 +30,7 @@ public func vergeSignpostEvent(_ event: StaticString) {
 @inlinable
 public func vergeSignpostEvent(_ event: StaticString, label: @autoclosure () -> String) {
   #if DEBUG
-  if #available(iOS 12, macOS 10.14, *) {
+  if #available(iOS 12, macOS 10.14, *), _verge_signpost_enabled {
     let id = OSSignpostID(log: SignpostConstants.pointOfInterestLog)
     os_signpost(.event, log: SignpostConstants.pointOfInterestLog, name: event, signpostID: id, "%@", label())
   }
@@ -48,7 +50,7 @@ public struct VergeSignpostTransaction {
   @inline(__always)
   public init(_ name: StaticString) {
     #if DEBUG
-    if #available(iOS 12, macOS 10.14, *) {
+    if #available(iOS 12, macOS 10.14, *), _verge_signpost_enabled {
       let id = OSSignpostID(log: SignpostConstants.performanceLog)
       self.rawID = id.rawValue
       os_signpost(.begin, log: SignpostConstants.performanceLog, name: name, signpostID: id)
@@ -67,7 +69,7 @@ public struct VergeSignpostTransaction {
   @inline(__always)
   public init(_ name: StaticString, label: @autoclosure () -> String) {
     #if DEBUG
-    if #available(iOS 12, macOS 10.14, *) {
+    if #available(iOS 12, macOS 10.14, *), _verge_signpost_enabled {
       let id = OSSignpostID(log: SignpostConstants.performanceLog)
       self.rawID = id.rawValue
       let _label = label()
@@ -87,7 +89,7 @@ public struct VergeSignpostTransaction {
   @inline(__always)
   public func event(name: StaticString, label: @autoclosure () -> String) {
     #if DEBUG
-    if #available(iOS 12, macOS 10.14, *) {
+    if #available(iOS 12, macOS 10.14, *), _verge_signpost_enabled {
       let id = OSSignpostID(rawID)
       os_signpost(.event, log: SignpostConstants.pointOfInterestLog, name: name, signpostID: id, "%@", label())
     }
@@ -98,7 +100,7 @@ public struct VergeSignpostTransaction {
   @inline(__always)
   public func event(name: StaticString) {
     #if DEBUG
-    if #available(iOS 12, macOS 10.14, *) {
+    if #available(iOS 12, macOS 10.14, *), _verge_signpost_enabled {
       let id = OSSignpostID(rawID)
       os_signpost(.event, log: SignpostConstants.pointOfInterestLog, name: name, signpostID: id)
     }


### PR DESCRIPTION
Using `signpost` to monitor performance metrics takes a bit of power of CPU over.
PR makes it disabled as default and put a global flag to enable monitoring.

`_verge_signpost_enabled = true`