### PR TITLE
Add BatchCommit

### DIFF
--- a/Docs/docs/VergeStore/mutation.md
+++ b/Docs/docs/VergeStore/mutation.md
@@ -14,7 +14,7 @@ That expresses that function is Mutation
 Mutation does **NOT** allow to run asynchronous operation.
 :::
 
-## To define mutations in the Store
+### Define mutations in the Store
 
 ```swift
 struct MyState {
@@ -32,7 +32,7 @@ class MyStore: Store<MyState, Never> {
 }
 ```
 
-## To run Mutation
+### Run Mutation
 
 ```swift
 let store = MyStore()
@@ -40,4 +40,73 @@ store.addNewTodo(title: "Create SwiftUI App")
 
 print(store.state.todos)
 // store.state.todos => [Todo(title: "Create SwiftUI App", hasCompleted: false)]
+```
+
+## Perform batch commits
+
+In a case that commits multiple mutations that can't be integrated, it will dispatch multiple updated events to each subscriber.  
+It means the application performance might be decreased.
+
+Like the following operation:
+
+```swift
+class MyStore: Store<MyState, Never> {
+
+  func myMutation() {
+    if ... {
+      commit {
+        ...
+      }
+      // emits updated event
+    }
+
+    if ... {
+      commit {
+        ...
+      }
+      // emits updated event
+    }
+
+    if ... {
+      commit {
+        ...
+      }
+      // emits updated event
+    }
+  }
+
+}
+```
+
+We can brush up with batching mutation feature.  
+`batchCommit` method groups multiple mutations then it applies at once.  
+If `batchCommit` has no operations, it happens nothing.
+
+```swift
+class MyStore: Store<MyState, Never> {
+
+  func myMutation() {
+    batchCommit { context in
+
+      if ... {
+        commit {
+          ...
+        }
+      }
+
+      if ... {
+        commit {
+          ...
+        }
+      }
+
+      if ... {
+        commit {
+          ...
+        }
+      }
+
+    }
+  }
+}
 ```

--- a/Sources/VergeStore/Store/DispatcherType.swift
+++ b/Sources/VergeStore/Store/DispatcherType.swift
@@ -131,3 +131,92 @@ extension DispatcherType {
   }
     
 }
+
+/**
+ A context to batch multiple mutations
+ */
+public struct BatchCommitContext<State, Scope> {
+
+  typealias Mutation = (MutationTrace, (inout State) -> Void)
+
+  private(set) var mutations: [Mutation] = []
+
+  let scope: WritableKeyPath<State, Scope>
+
+  init(scope: WritableKeyPath<State, Scope>) {
+    self.scope = scope
+  }
+
+  /// Registers Mutation that created inline
+  public mutating func commit(
+    _ name: String = "",
+    _ file: StaticString = #file,
+    _ function: StaticString = #function,
+    _ line: UInt = #line,
+    mutation: @escaping (inout Scope) -> Void
+  ) {
+
+    let trace = MutationTrace(
+      name: name,
+      file: file.description,
+      function: function.description,
+      line: line
+    )
+
+    mutations.append((trace, { [scope] state in
+      mutation(&state[keyPath: scope])
+    }))
+
+  }
+
+  /// Registers Mutation that created inline
+  public mutating func commit<NewScope>(
+    _ name: String = "",
+    _ file: StaticString = #file,
+    _ function: StaticString = #function,
+    _ line: UInt = #line,
+    scope: WritableKeyPath<State, NewScope>,
+    mutation: @escaping (inout NewScope) -> Void
+  ) {
+
+    let trace = MutationTrace(
+      name: name,
+      file: file.description,
+      function: function.description,
+      line: line
+    )
+
+    mutations.append((trace, { state in
+      mutation(&state[keyPath: scope])
+    }))
+
+  }
+
+}
+
+extension DispatcherType {
+
+  /**
+   Performs multiple commits at once.
+   From calling this method a transaction starts, register mutation into `BatchUpdate` instance.
+   If it has no mutations, batch updating won't be executed.
+   */
+  public func batchCommit(_ perform: (_ context: inout BatchCommitContext<WrappedStore.State, Scope>) -> Void) {
+
+    var context = BatchCommitContext<WrappedStore.State, Scope>(scope: scope)
+
+    perform(&context)
+
+    guard !context.mutations.isEmpty else {
+      return
+    }
+
+    commit("BatchUpdating", scope: \.self) { (state) -> Void in
+      for mutation in context.mutations {
+        mutation.1(&state)
+      }
+    }
+
+  }
+
+}

--- a/Tests/VergeStoreTests/VergeStoreTests.swift
+++ b/Tests/VergeStoreTests/VergeStoreTests.swift
@@ -467,5 +467,39 @@ final class VergeStoreTests: XCTestCase {
     withExtendedLifetime(subscription) {}
     wait(for: [expect], timeout: 1)
   }
+
+  func testBatchCommits() {
+
+    let store1 = DemoStore()
+
+    XCTAssertEqual(store1.state.version, 0)
+
+    store1.batchCommit { (context) in
+      context.commit {
+        $0.count += 1
+      }
+    }
+
+    XCTAssertEqual(store1.state.version, 1)
+
+  }
+
+  func testBatchCommitsNoCommits() {
+
+    let store1 = DemoStore()
+
+    XCTAssertEqual(store1.state.version, 0)
+
+    store1.batchCommit { (context) in
+      if false {
+        context.commit {
+          $0.count += 1
+        }
+      }
+    }
+
+    XCTAssertEqual(store1.state.version, 0)
+
+  }
   
 }


### PR DESCRIPTION
## Perform batch commits

In a case that commits multiple mutations that can't be integrated, it will dispatch multiple updated events to each subscriber.  
It means the application performance might be decreased.

Like the following operation:

```swift
class MyStore: Store<MyState, Never> {

  func myMutation() {
    if ... {
      commit {
        ...
      }
      // emits updated event
    }

    if ... {
      commit {
        ...
      }
      // emits updated event
    }

    if ... {
      commit {
        ...
      }
      // emits updated event
    }
  }

}
```

We can brush up with batching mutation feature.  
`batchCommit` method groups multiple mutations then it applies at once.  
If `batchCommit` has no operations, it happens nothing.

```swift
class MyStore: Store<MyState, Never> {

  func myMutation() {
    batchCommit { context in

      if ... {
        commit {
          ...
        }
      }

      if ... {
        commit {
          ...
        }
      }

      if ... {
        commit {
          ...
        }
      }

    }
  }
}
```
