### PR TITLE
Change default argument in sink and derived

### DIFF
--- a/Sources/VergeStore/Store/Derived+Assign.swift
+++ b/Sources/VergeStore/Store/Derived+Assign.swift
@@ -92,7 +92,7 @@ extension Derived {
   public func assign(
     to binder: @escaping (Changes<Value>) -> Void
   ) -> VergeAnyCancellable {
-    sinkValue { c in
+    sinkValue(queue: .passthrough) { c in
       binder(c)
     }
   }

--- a/Sources/VergeStore/Store/Derived.swift
+++ b/Sources/VergeStore/Store/Derived.swift
@@ -541,7 +541,7 @@ extension StoreType {
   /// Creates an instance of Derived
   private func _makeDerived<NewState>(
     _ memoizeMap: MemoizeMap<Changes<State>, NewState>,
-    queue: TargetQueue? = nil
+    queue: TargetQueue?
   ) -> Derived<NewState> {
     
     vergeSignpostEvent("Store.derived.new", label: "\(type(of: State.self)) -> \(type(of: NewState.self))")
@@ -572,7 +572,7 @@ extension StoreType {
   public func derived<NewState>(
     _ memoizeMap: MemoizeMap<Changes<State>, NewState>,
     dropsOutput: ((Changes<NewState>) -> Bool)? = nil,
-    queue: TargetQueue? = nil
+    queue: TargetQueue? = .asyncSerialBackground
   ) -> Derived<NewState> {
         
     let derived = asStore().derivedCache2.withValue { cache -> Derived<NewState> in
@@ -610,7 +610,7 @@ extension StoreType {
   /// - Returns: Derived object that cached depends on the specified parameters
   public func derived<NewState: Equatable>(
     _ memoizeMap: MemoizeMap<Changes<State>, NewState>,
-    queue: TargetQueue? = nil
+    queue: TargetQueue? = .asyncSerialBackground
   ) -> Derived<NewState> {
     
     return asStore().derivedCache1.withValue { cache in
@@ -662,7 +662,11 @@ extension StoreType {
     },
       initialUpstreamState: asStore().state,
       subscribeUpstreamState: { callback in
-        asStore().sinkState(dropsFirst: true, queue: nil, receive: callback)
+        asStore().sinkState(
+          dropsFirst: true,
+          queue: .asyncSerialBackground,
+          receive: callback
+        )
     }, retainsUpstream: nil)
     
     derived.setDropsOutput(dropsOutput)

--- a/Sources/VergeStore/Store/Store.swift
+++ b/Sources/VergeStore/Store/Store.swift
@@ -221,46 +221,30 @@ open class Store<State, Activity>: _VergeObservableObjectBase, CustomReflectable
   /// - Returns: A subscriber that performs the provided closure upon receiving values.
   public func sinkState(
     dropsFirst: Bool = false,
-    queue: TargetQueue? = nil,
+    queue: TargetQueue = .asyncMain,
     receive: @escaping (Changes<State>) -> Void
   ) -> VergeAnyCancellable {
     
-    if let execute = queue?.executor() {
+    let execute = queue.executor()
 
-      /// Firstly, it registers a closure to make sure that it receives all of the updates, even updates inside the first call.
-      let cancellable = _backingStorage.addDidUpdate { newValue in
-        execute {
-          receive(newValue)
-        }
-      }
-
-      if !dropsFirst {
-        let value = _backingStorage.value.droppedPrevious()
-        execute {
-          /// this closure might contains some mutations.
-          ///  It depends outside usages.
-          receive(value)
-        }
-      }
-
-      return .init(cancellable)
-      
-    } else {
-
-      /// Firstly, it registers a closure to make sure that it receives all of the updates, even updates inside the first call.
-      let cancellable = _backingStorage.addDidUpdate { newValue in
+    /// Firstly, it registers a closure to make sure that it receives all of the updates, even updates inside the first call.
+    let cancellable = _backingStorage.addDidUpdate { newValue in
+      execute {
         receive(newValue)
       }
+    }
 
-      if !dropsFirst {
+    if !dropsFirst {
+      let value = _backingStorage.value.droppedPrevious()
+      execute {
         /// this closure might contains some mutations.
         ///  It depends outside usages.
-        receive(_backingStorage.value.droppedPrevious())
+        receive(value)
       }
-      
-      return .init(cancellable)
     }
-    
+
+    return .init(cancellable)
+
   }
 
   /// Subscribe the state changes
@@ -275,7 +259,7 @@ open class Store<State, Activity>: _VergeObservableObjectBase, CustomReflectable
   public func sinkState<Accumulate>(
     scan: Scan<Changes<State>, Accumulate>,
     dropsFirst: Bool = false,
-    queue: TargetQueue? = nil,
+    queue: TargetQueue = .asyncMain,
     receive: @escaping (Changes<State>, Accumulate) -> Void
   ) -> VergeAnyCancellable {
 
@@ -287,65 +271,22 @@ open class Store<State, Activity>: _VergeObservableObjectBase, CustomReflectable
 
   }
 
-  /// Subscribe the state changes
-  ///
-  /// - Returns: A subscriber that performs the provided closure upon receiving values.
-  @available(*, deprecated, renamed: "sinkState")
-  public func sinkChanges(
-    dropsFirst: Bool = false,
-    queue: TargetQueue? = nil,
-    receive: @escaping (Changes<State>) -> Void
-  ) -> VergeAnyCancellable {
-    sinkState(dropsFirst: dropsFirst, queue: queue, receive: receive)
-  }
-  
-  /// Subscribe the state changes
-  ///
-  /// - Returns: A subscriber that performs the provided closure upon receiving values.
-  @available(*, deprecated, renamed: "sinkState")
-  public func subscribeChanges(
-    dropsFirst: Bool = false,
-    queue: TargetQueue? = nil,
-    receive: @escaping (Changes<State>) -> Void
-  ) -> VergeAnyCancellable {
-    sinkState(dropsFirst: dropsFirst, queue: queue, receive: receive)
-  }
-  
   /// Subscribe the activity
   ///
   /// - Returns: A subscriber that performs the provided closure upon receiving values.
   public func sinkActivity(
-    queue: TargetQueue? = nil,
+    queue: TargetQueue = .asyncMain,
     receive: @escaping (Activity) -> Void
   ) -> VergeAnyCancellable {
     
-    if let execute = queue?.executor() {
-      let cancellable = _activityEmitter.add { (activity) in
-        execute {
-          receive(activity)
-        }
-      }
-      return .init(cancellable)
-    } else {
-      //      let lock = NSRecursiveLock()
-      let cancellable = _activityEmitter.add { activity in
-        //        lock.lock(); defer { lock.unlock() }
+    let execute = queue.executor()
+    let cancellable = _activityEmitter.add { (activity) in
+      execute {
         receive(activity)
       }
-      return .init(cancellable)
     }
-    
+    return .init(cancellable)
+
   }
-  
-  /// Subscribe the activity
-  ///
-  /// - Returns: A subscriber that performs the provided closure upon receiving values.
-  @available(*, deprecated, renamed: "sinkActivity")
-  public func subscribeActivity(
-    queue: TargetQueue? = nil,
-    receive: @escaping (Activity) -> Void
-  ) -> VergeAnyCancellable {
-    sinkActivity(queue: queue, receive: receive)
-  }
-             
+
 }

--- a/Sources/VergeStore/StoreWrapperType.swift
+++ b/Sources/VergeStore/StoreWrapperType.swift
@@ -102,7 +102,7 @@ extension StoreComponentType {
   /// - Returns: A subscriber that performs the provided closure upon receiving values.
   public func sinkState(
     dropsFirst: Bool = false,
-    queue: TargetQueue? = nil,
+    queue: TargetQueue = .asyncMain,
     receive: @escaping (Changes<WrappedStore.State>) -> Void
   ) -> VergeAnyCancellable {
     store.asStore().sinkState(dropsFirst: dropsFirst, queue: queue, receive: receive)
@@ -120,57 +120,22 @@ extension StoreComponentType {
   public func sinkState<Accumulate>(
     scan: Scan<Changes<WrappedStore.State>, Accumulate>,
     dropsFirst: Bool = false,
-    queue: TargetQueue? = nil,
+    queue: TargetQueue = .asyncMain,
     receive: @escaping (Changes<WrappedStore.State>, Accumulate) -> Void
   ) -> VergeAnyCancellable {
     store.asStore().sinkState(scan: scan, dropsFirst: dropsFirst, queue: queue, receive: receive)
   }
 
-  /// Subscribe the state changes
-  ///
-  /// - Returns: A subscriber that performs the provided closure upon receiving values.
-  @available(*, deprecated, renamed: "sinkState")
-  public func sinkChanges(
-    dropsFirst: Bool = false,
-    queue: TargetQueue? = nil,
-    receive: @escaping (Changes<WrappedStore.State>) -> Void
-  ) -> VergeAnyCancellable {
-    store.asStore().sinkState(dropsFirst: dropsFirst, queue: queue, receive: receive)
-  }
-  
-  /// Subscribe the state changes
-  ///
-  /// - Returns: A subscriber that performs the provided closure upon receiving values.
-  @available(*, deprecated, renamed: "sinkState")
-  public func subscribeChanges(
-    dropsFirst: Bool = false,
-    queue: TargetQueue? = nil,
-    receive: @escaping (Changes<WrappedStore.State>) -> Void
-  ) -> VergeAnyCancellable {
-    store.asStore().sinkChanges(dropsFirst: dropsFirst, queue: queue, receive: receive)
-  }
-  
   /// Subscribe the activity
   ///
   /// - Returns: A subscriber that performs the provided closure upon receiving values.
   public func sinkActivity(
-    queue: TargetQueue? = nil,
+    queue: TargetQueue = .asyncMain,
     receive: @escaping (WrappedStore.Activity) -> Void
   ) -> VergeAnyCancellable  {
     store.asStore().sinkActivity(queue: queue, receive: receive)
   }
-  
-  /// Subscribe the activity
-  ///
-  /// - Returns: A subscriber that performs the provided closure upon receiving values.
-  @available(*, deprecated, renamed: "sinkActivity")
-  public func subscribeActivity(
-    queue: TargetQueue? = nil,
-    receive: @escaping (WrappedStore.Activity) -> Void
-  ) -> VergeAnyCancellable  {
-    store.asStore().sinkActivity(queue: queue, receive: receive)
-  }
-      
+ 
 }
 
 #if canImport(Combine)

--- a/Sources/VergeStore/TargetQueue.swift
+++ b/Sources/VergeStore/TargetQueue.swift
@@ -45,6 +45,10 @@ public struct TargetQueue {
 
 fileprivate enum TargetQueue_StaticMember {
 
+  static let passthrough: TargetQueue = .init(identifier: "passthrough") { workItem in
+    workItem()
+  }
+
   static let main: TargetQueue = .init(identifier: "main") { workItem in
     if Thread.isMainThread {
       workItem()
@@ -66,6 +70,11 @@ fileprivate enum TargetQueue_StaticMember {
 }
 
 extension TargetQueue {
+
+  /// It never dispatches.
+  public static var passthrough: TargetQueue {
+    TargetQueue_StaticMember.passthrough
+  }
 
   /// It dispatches to main-queue as possible as synchronously. Otherwise, it dispatches asynchronously from other background-thread.
   public static var main: TargetQueue {

--- a/Tests/VergeORMTests/DerivedTests.swift
+++ b/Tests/VergeORMTests/DerivedTests.swift
@@ -21,7 +21,7 @@ class DerivedTests: XCTestCase {
     
     let id = Book.EntityID.init("some")
     
-    let nullableSelector = storage.derived(from: id)
+    let nullableSelector = storage.derived(from: id, queue: .passthrough)
     
     XCTAssertNil(nullableSelector.primitiveValue.wrapped)
     
@@ -52,7 +52,8 @@ class DerivedTests: XCTestCase {
       }
       
       let selector = storage.derivedNonNull(
-        from: book
+        from: book,
+        queue: .passthrough
       )
       
       XCTAssertNotNil(nullableSelector.primitiveValue.wrapped)
@@ -112,7 +113,7 @@ class DerivedTests: XCTestCase {
         }
       }
             
-      let selector = storage.derivedNonNull(from: result)
+      let selector = storage.derivedNonNull(from: result, queue: .passthrough)
       
       XCTAssertEqual(selector.primitiveValue.rawID, "some")
       XCTAssertEqual(selector.primitiveValue.name, "")
@@ -165,7 +166,7 @@ class DerivedTests: XCTestCase {
     
     var updatedCount = 0
     
-    let authorGetter = storage.derivedNonNull(from: result)
+    let authorGetter = storage.derivedNonNull(from: result, queue: .passthrough)
     
     authorGetter.valuePublisher()
       .dropFirst(1).sink { _ in
@@ -250,7 +251,7 @@ class DerivedTests: XCTestCase {
     let storage = Store<RootState, Never>.init(initialState: .init(), logger: nil)
     
     measure {
-      let _ = storage.derived(from: Author.EntityID("Hoo"))
+      let _ = storage.derived(from: Author.EntityID("Hoo"), queue: .passthrough)
     }
     
   }
@@ -259,10 +260,10 @@ class DerivedTests: XCTestCase {
     
     let storage = Store<RootState, Never>.init(initialState: .init(), logger: nil)
     
-    let _ = storage.derived(from: Author.EntityID("Hoo"))
+    let _ = storage.derived(from: Author.EntityID("Hoo"), queue: .passthrough)
     
     measure {
-      let _ = storage.derived(from: Author.EntityID("Hoo"))
+      let _ = storage.derived(from: Author.EntityID("Hoo"), queue: .passthrough)
     }
     
   }

--- a/Tests/VergeStoreTests/ComputedTests.swift
+++ b/Tests/VergeStoreTests/ComputedTests.swift
@@ -373,7 +373,7 @@ class Computed2Tests: XCTestCase {
     
     let store = MyStore()
             
-    let sub = store.sinkState { (changes) in
+    let sub = store.sinkState(queue: .passthrough) { (changes) in
       
       _ = changes.computed.nameCount
       _ = changes.computed.nameCount
@@ -410,7 +410,7 @@ class Computed2Tests: XCTestCase {
     var store: MyStore! = MyStore()
     weak var _store = store
     
-    let subscription = store.sinkState { (changes) in
+    let subscription = store.sinkState(queue: .passthrough) { (changes) in
 
       _ = changes.computed.nameCount
       _ = changes.computed.nameCount

--- a/Tests/VergeStoreTests/DerivedTests.swift
+++ b/Tests/VergeStoreTests/DerivedTests.swift
@@ -106,7 +106,7 @@ final class DerivedTests: XCTestCase {
     expectation.expectedFulfillmentCount = 1
     expectation.assertForOverFulfill = true
     
-    let subscription = baseSlice.sinkValue(dropsFirst: true) { (changes) in
+    let subscription = baseSlice.sinkValue(dropsFirst: true, queue: .passthrough) { (changes) in
       expectation.fulfill()
     }
 

--- a/Tests/VergeStoreTests/DerivedTests.swift
+++ b/Tests/VergeStoreTests/DerivedTests.swift
@@ -17,7 +17,7 @@ final class DerivedTests: XCTestCase {
   
   func testSlice() {
                 
-    let slice = wrapper.derived(.map { $0.count })
+    let slice = wrapper.derived(.map { $0.count }, queue: .passthrough)
 
     XCTAssertEqual(slice.primitiveValue, 0)
     XCTAssertEqual(slice.value.root, 0)
@@ -50,7 +50,11 @@ final class DerivedTests: XCTestCase {
 
   func testSlice2() {
 
-    let slice = wrapper.derived(.map { $0.count }, dropsOutput: { $0.noChanges(\.root) })
+    let slice = wrapper.derived(
+      .map { $0.count },
+      dropsOutput: { $0.noChanges(\.root) },
+      queue: .passthrough
+    )
 
     XCTAssertEqual(slice.primitiveValue, 0)
     XCTAssertEqual(slice.value.root, 0)
@@ -99,7 +103,7 @@ final class DerivedTests: XCTestCase {
   
   func testRetain() {
     
-    var baseSlice: Derived<Int>! = wrapper.derived(.map { $0.count })
+    var baseSlice: Derived<Int>! = wrapper.derived(.map { $0.count }, queue: .passthrough)
     weak var weakBaseSlice = baseSlice
     
     let expectation = XCTestExpectation(description: "receive changes")
@@ -130,11 +134,11 @@ final class DerivedTests: XCTestCase {
   
   func testSliceChain() {
     
-    var baseSlice: Derived<Int>! = wrapper.derived(.map { $0.count })
+    var baseSlice: Derived<Int>! = wrapper.derived(.map { $0.count }, queue: .passthrough)
     
     weak var weakBaseSlice = baseSlice
             
-    var slice: Derived<Int>! = baseSlice.chain(.map { $0.root })
+    var slice: Derived<Int>! = baseSlice.chain(.map { $0.root }, queue: .passthrough)
     
     baseSlice = nil
     
@@ -176,8 +180,8 @@ final class DerivedTests: XCTestCase {
   /// combine 2 stored
   func testCombine2() {
     
-    let s0 = wrapper.derived(.map { $0.count })
-    let s1 = wrapper.derived(.map { $0.name })
+    let s0 = wrapper.derived(.map { $0.count }, queue: .passthrough)
+    let s1 = wrapper.derived(.map { $0.name }, queue: .passthrough)
     
     let updateCount = expectation(description: "updatecount")
     updateCount.assertForOverFulfill = true
@@ -228,8 +232,8 @@ final class DerivedTests: XCTestCase {
   /// combine 1 Stored and 1 Computed
   func testCombine2computed() {
     
-    let s0 = wrapper.derived(.map { $0.count })
-    let s1 = wrapper.derived(.map { $0.computed.nameCount })
+    let s0 = wrapper.derived(.map { $0.count }, queue: .passthrough)
+    let s1 = wrapper.derived(.map { $0.computed.nameCount }, queue: .passthrough)
     
     let updateCount = expectation(description: "updatecount")
     updateCount.assertForOverFulfill = true
@@ -243,7 +247,7 @@ final class DerivedTests: XCTestCase {
     update1.assertForOverFulfill = true
     update1.expectedFulfillmentCount = 2
     
-    let d = Derived.combined(s0, s1)
+    let d = Derived.combined(s0, s1, queue: .passthrough)
     
     XCTAssert(d.primitiveValue == (0, 0))
     

--- a/Tests/VergeStoreTests/DerivedTests.swift
+++ b/Tests/VergeStoreTests/DerivedTests.swift
@@ -195,7 +195,7 @@ final class DerivedTests: XCTestCase {
     update1.assertForOverFulfill = true
     update1.expectedFulfillmentCount = 2
     
-    let d = Derived.combined(s0, s1)
+    let d = Derived.combined(s0, s1, queue: .passthrough)
     
     XCTAssert(d.primitiveValue == (0, ""))
         

--- a/Tests/VergeStoreTests/VergeStoreTests.swift
+++ b/Tests/VergeStoreTests/VergeStoreTests.swift
@@ -259,7 +259,7 @@ final class VergeStoreTests: XCTestCase {
     var subscriptions = Set<VergeAnyCancellable>()
     var count = 0
     
-    store.sinkState { (changes) in
+    store.sinkState(queue: .passthrough) { (changes) in
       count += 1
     }
     .store(in: &subscriptions)

--- a/Tests/VergeStoreTests/VergeStoreTests.swift
+++ b/Tests/VergeStoreTests/VergeStoreTests.swift
@@ -366,7 +366,7 @@ final class VergeStoreTests: XCTestCase {
     let store2 = DemoStore()
     
     let sub = store1
-      .derived(.map(\.count))
+      .derived(.map(\.count), queue: .passthrough)
       .assign(to: \.count, on: store2)
     
     store1.commit {
@@ -391,7 +391,7 @@ final class VergeStoreTests: XCTestCase {
     let store2 = DemoStore()
     
     let sub = store1
-      .derived(.map(\.count))
+      .derived(.map(\.count), queue: .passthrough)
       .assign(to: store2.assignee(\.count))
     
     store1.commit {
@@ -426,7 +426,7 @@ final class VergeStoreTests: XCTestCase {
       init(sourceStore: DemoStore) {
         
         let d = sourceStore
-          .derived(.map(\.count))
+          .derived(.map(\.count), queue: .passthrough)
         
         self.store = .init(initialState: .init(source: d.value), logger: nil)
         


### PR DESCRIPTION
To be faster in mutating the state.
Currently, starting Sink and deriving value from the state are running never dispatching as default.
that means the commit operations have to wait for it until all of the updating value finished.

As an original strategy, I decided to use such as this current behavior to achieve an easier way to debug because we can see all of stack-trace with running synchronously.

However, in most cases in the real world, it is not necessary from my current view.
Basically new value from subscribing like `sink` except creating Derive object. (Derive object requires the first value synchronously in init.)

So, This PR offers us to use DispatchQueue with asynchronously to receive a new value.
There are differences in Sink and making Derived.

Sink uses `.asyncMain` : it always dispatches to main-queue to deliver new value to the closure.
Derived object uses `.asyncSerialBackground` : it always dispatches to the background serial queue to derive new value.

In according, commit operation becomes no needs to wait for finishing updating values for each subscriber.

If you need to receive a new value synchronously, you can specify `.passthrough` like our unit testing code.
