### PR TITLE
Fix TargetQueue.main

### DIFF
--- a/Sources/VergeStore/TargetQueue.swift
+++ b/Sources/VergeStore/TargetQueue.swift
@@ -20,7 +20,10 @@
 // THE SOFTWARE.
 
 import Foundation
+
+#if !COCOAPODS
 import VergeCore
+#endif
 
 /// Describes queue to dispatch event
 /// Currently light-weight impl

--- a/Tests/VergeStoreTests/DerivedTests.swift
+++ b/Tests/VergeStoreTests/DerivedTests.swift
@@ -301,10 +301,26 @@ final class DerivedCacheTests: XCTestCase {
     
     let store1 = DemoStore()
     let store2 = DemoStore()
+
+    XCTAssert(
+      store1.derived(.map(\.count), queue: .asyncMain) ===
+        store1.derived(.map(\.count), queue: .asyncMain)
+    )
     
-    XCTAssert(store1.derived(.map(\.count), queue: .main) === store1.derived(.map(\.count), queue: .main))
-    XCTAssert(store1.derived(.map(\.count)) !== store1.derived(.map(\.count), queue: .main))
-    XCTAssert(store1.derived(.map(\.count)) !== store2.derived(.map(\.count)))
+    XCTAssert(
+      store1.derived(.map(\.count), queue: .main()) !==
+        store1.derived(.map(\.count), queue: .main())
+    )
+
+    XCTAssert(
+      store1.derived(.map(\.count)) !==
+        store1.derived(.map(\.count), queue: .main())
+    )
+
+    XCTAssert(
+      store1.derived(.map(\.count)) !==
+        store2.derived(.map(\.count))
+    )
     
   }
   
@@ -317,7 +333,7 @@ final class DerivedCacheTests: XCTestCase {
     let queue2 = TargetQueue.specific(DispatchQueue(label: "test"))
     
     XCTAssert(store1.derived(.map(\.count), queue: queue) === store1.derived(.map(\.count), queue: queue))
-    XCTAssert(store1.derived(.map(\.count), queue: queue) !== store1.derived(.map(\.count), queue: .main))
+    XCTAssert(store1.derived(.map(\.count), queue: queue) !== store1.derived(.map(\.count), queue: .main()))
     XCTAssert(store1.derived(.map(\.count), queue: queue) !== store1.derived(.map(\.count), queue: queue2))
     XCTAssert(store1.derived(.map(\.count)) !== store2.derived(.map(\.count)))
         
@@ -331,7 +347,7 @@ final class DerivedCacheTests: XCTestCase {
     let queue = TargetQueue.specific(DispatchQueue.global())
     
     XCTAssert(store1.derived(.map(\.count), queue: queue) === store1.derived(.map(\.count), queue: queue))
-    XCTAssert(store1.derived(.map(\.count), queue: queue) !== store1.derived(.map(\.count), queue: .main))
+    XCTAssert(store1.derived(.map(\.count), queue: queue) !== store1.derived(.map(\.count), queue: .main()))
     XCTAssert(store1.derived(.map(\.count)) !== store2.derived(.map(\.count)))
     
   }


### PR DESCRIPTION
## Summary
It fixes an issue in TargetQueue.main.
What a TargetQueue.main's issue is that queue can accept a work item concurrently and runs.
That has been fixed with processing the work items correct order by commits.

## Detail
Previous TargetQueue.main can accept a work item from any queue.
And if that comes from MainQueue, that would be processed immediately without dispatching in main-queue to be faster as possible.
However, in that time DispatchQueue.main has already one or more tasks asynchronously. 
That means the task that comes from MainQueue could be processed earlier than the queued one.
That could be a serious problem, So that fixed according to RxSwift's MainScheduler.

https://github.com/ReactiveX/RxSwift/blob/main/RxSwift/Schedulers/MainScheduler.swift#L60