### PR TITLE
Changes contains MutationTrace

### DIFF
--- a/Sources/VergeRx/Store+Rx.swift
+++ b/Sources/VergeRx/Store+Rx.swift
@@ -80,16 +80,29 @@ extension ObservableType {
     
   /// Make Changes sequense from current sequence
   /// - Returns:
-  public func changes(initial: Changes<Element>? = nil) -> Observable<Changes<Element>> {
+  public func changes(
+    initial: Changes<Element>? = nil,
+    _ name: String = "",
+    _ file: StaticString = #file,
+    _ function: StaticString = #function,
+    _ line: UInt = #line
+  ) -> Observable<Changes<Element>> {
+
+    let trace = MutationTrace(
+      name: name,
+      file: file,
+      function: function,
+      line: line
+    )
     
-    scan(into: initial, accumulator: { (pre, element) in
+    return scan(into: initial, accumulator: { (pre, element) in
       if pre == nil {
         pre = Changes<Element>.init(old: nil, new: element)
       } else {
-        pre = pre!.makeNextChanges(with: element)
+        pre = pre!.makeNextChanges(with: element, from: trace)
       }
     })
-      .map { $0! }
+    .map { $0! }
 
   }
   

--- a/Sources/VergeStore/BatchCommit.swift
+++ b/Sources/VergeStore/BatchCommit.swift
@@ -47,8 +47,8 @@ public struct BatchCommitContext<State, Scope> {
 
     let trace = MutationTrace(
       name: name,
-      file: file.description,
-      function: function.description,
+      file: file,
+      function: function,
       line: line
     )
 
@@ -72,8 +72,8 @@ public struct BatchCommitContext<State, Scope> {
 
     let trace = MutationTrace(
       name: name,
-      file: file.description,
-      function: function.description,
+      file: file,
+      function: function,
       line: line
     )
 
@@ -97,8 +97,8 @@ public struct BatchCommitContext<State, Scope> {
 
     let trace = MutationTrace(
       name: name,
-      file: file.description,
-      function: function.description,
+      file: file,
+      function: function,
       line: line
     )
 

--- a/Sources/VergeStore/Store/DispatcherType.swift
+++ b/Sources/VergeStore/Store/DispatcherType.swift
@@ -82,8 +82,8 @@ extension DispatcherType {
     
     let trace = MutationTrace(
       name: name,
-      file: file.description,
-      function: function.description,
+      file: file,
+      function: function,
       line: line
     )
     
@@ -111,8 +111,8 @@ extension DispatcherType {
     
     let trace = MutationTrace(
       name: name,
-      file: file.description,
-      function: function.description,
+      file: file,
+      function: function,
       line: line
     )
     
@@ -141,8 +141,8 @@ extension DispatcherType {
 
     let trace = MutationTrace(
       name: name,
-      file: file.description,
-      function: function.description,
+      file: file,
+      function: function,
       line: line
     )
 

--- a/Sources/VergeStore/Store/MutationTrace.swift
+++ b/Sources/VergeStore/Store/MutationTrace.swift
@@ -26,8 +26,16 @@ public struct MutationTrace: Encodable {
     
   public let createdAt: Date = .init()
   public let name: String
-  public let file: String
-  public let function: String
+  public let file: StaticString
+  public let function: StaticString
   public let line: UInt
 
+}
+
+extension StaticString: Encodable {
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(description)
+  }
 }

--- a/Sources/VergeStore/Store/MutationTrace.swift
+++ b/Sources/VergeStore/Store/MutationTrace.swift
@@ -23,12 +23,24 @@ import Foundation
 
 /// A trace that indicates the mutation where comes from.
 public struct MutationTrace: Encodable {
-    
+
   public let createdAt: Date = .init()
   public let name: String
   public let file: StaticString
   public let function: StaticString
   public let line: UInt
+
+  public init(
+    name: String,
+    file: StaticString,
+    function: StaticString,
+    line: UInt
+  ) {
+    self.name = name
+    self.file = file
+    self.function = function
+    self.line = line
+  }
 
 }
 

--- a/Sources/VergeStore/Store/Store.swift
+++ b/Sources/VergeStore/Store/Store.swift
@@ -194,7 +194,7 @@ open class Store<State, Activity>: _VergeObservableObjectBase, CustomReflectable
           return .nothingUpdates
         }
 
-        state = state.makeNextChanges(with: pointer.pointee)
+        state = state.makeNextChanges(with: pointer.pointee, from: trace)
 
         return .updated
       }


### PR DESCRIPTION
It enables debugging in `Changes`.
`Changes` contains MutationTrace which indicates where were happened that mutation.