### PR TITLE
Changes default parameter which is queue in sink -> .mainIsolated()

### DIFF
--- a/Sources/VergeStore/Store/Derived.swift
+++ b/Sources/VergeStore/Store/Derived.swift
@@ -178,7 +178,7 @@ public class Derived<Value>: _VergeObservableObjectBase, DerivedType {
   /// - Returns: A subscriber that performs the provided closure upon receiving values.
   public func sinkValue(
     dropsFirst: Bool = false,
-    queue: TargetQueue = .main,
+    queue: TargetQueue = .mainIsolated(),
     receive: @escaping (Changes<Value>) -> Void
   ) -> VergeAnyCancellable {
     
@@ -204,7 +204,7 @@ public class Derived<Value>: _VergeObservableObjectBase, DerivedType {
   public func sinkValue<Accumulate>(
     scan: Scan<Changes<Value>, Accumulate>,
     dropsFirst: Bool = false,
-    queue: TargetQueue = .main,
+    queue: TargetQueue = .mainIsolated(),
     receive: @escaping (Changes<Value>, Accumulate) -> Void
   ) -> VergeAnyCancellable {
     innerStore.sinkState(scan: scan, dropsFirst: dropsFirst, queue: queue, receive: receive)

--- a/Sources/VergeStore/Store/Store.swift
+++ b/Sources/VergeStore/Store/Store.swift
@@ -253,7 +253,7 @@ open class Store<State, Activity>: _VergeObservableObjectBase, CustomReflectable
   /// - Returns: A subscriber that performs the provided closure upon receiving values.
   public func sinkState(
     dropsFirst: Bool = false,
-    queue: TargetQueue = .main,
+    queue: TargetQueue = .mainIsolated(),
     receive: @escaping (Changes<State>) -> Void
   ) -> VergeAnyCancellable {
     
@@ -291,7 +291,7 @@ open class Store<State, Activity>: _VergeObservableObjectBase, CustomReflectable
   public func sinkState<Accumulate>(
     scan: Scan<Changes<State>, Accumulate>,
     dropsFirst: Bool = false,
-    queue: TargetQueue = .main,
+    queue: TargetQueue = .mainIsolated(),
     receive: @escaping (Changes<State>, Accumulate) -> Void
   ) -> VergeAnyCancellable {
 
@@ -307,7 +307,7 @@ open class Store<State, Activity>: _VergeObservableObjectBase, CustomReflectable
   ///
   /// - Returns: A subscriber that performs the provided closure upon receiving values.
   public func sinkActivity(
-    queue: TargetQueue = .main,
+    queue: TargetQueue = .mainIsolated(),
     receive: @escaping (Activity) -> Void
   ) -> VergeAnyCancellable {
     

--- a/Sources/VergeStore/StoreWrapperType.swift
+++ b/Sources/VergeStore/StoreWrapperType.swift
@@ -102,7 +102,7 @@ extension StoreComponentType {
   /// - Returns: A subscriber that performs the provided closure upon receiving values.
   public func sinkState(
     dropsFirst: Bool = false,
-    queue: TargetQueue = .main,
+    queue: TargetQueue = .mainIsolated(),
     receive: @escaping (Changes<WrappedStore.State>) -> Void
   ) -> VergeAnyCancellable {
     store.asStore().sinkState(dropsFirst: dropsFirst, queue: queue, receive: receive)
@@ -120,7 +120,7 @@ extension StoreComponentType {
   public func sinkState<Accumulate>(
     scan: Scan<Changes<WrappedStore.State>, Accumulate>,
     dropsFirst: Bool = false,
-    queue: TargetQueue = .main,
+    queue: TargetQueue = .mainIsolated(),
     receive: @escaping (Changes<WrappedStore.State>, Accumulate) -> Void
   ) -> VergeAnyCancellable {
     store.asStore().sinkState(scan: scan, dropsFirst: dropsFirst, queue: queue, receive: receive)
@@ -130,7 +130,7 @@ extension StoreComponentType {
   ///
   /// - Returns: A subscriber that performs the provided closure upon receiving values.
   public func sinkActivity(
-    queue: TargetQueue = .main,
+    queue: TargetQueue = .mainIsolated(),
     receive: @escaping (WrappedStore.Activity) -> Void
   ) -> VergeAnyCancellable  {
     store.asStore().sinkActivity(queue: queue, receive: receive)

--- a/Sources/VergeStore/TargetQueue.swift
+++ b/Sources/VergeStore/TargetQueue.swift
@@ -112,6 +112,24 @@ extension TargetQueue {
   public static var asyncSerialBackground: TargetQueue = .init { workItem in
     StaticMember.serialBackgroundDispatchQueue.async(execute: workItem)
   }
+
+  /// Enqueue first item on current-thread(synchronously).
+  /// From then, using specified queue.
+  public static func startsFromCurrentThread(and queue: TargetQueue) -> TargetQueue {
+
+    let numberEnqueued = VergeConcurrency.AtomicReference.init(initialValue: false)
+
+    return .init { workItem in
+
+      let isFirst = numberEnqueued.compareAndSet(expect: false, newValue: true)
+
+      if isFirst {
+        workItem()
+      } else {
+        queue.schedule(workItem)
+      }
+    }
+  }
 }
 
 

--- a/Sources/VergeStore/TargetQueue.swift
+++ b/Sources/VergeStore/TargetQueue.swift
@@ -115,7 +115,7 @@ extension TargetQueue {
 
   /// Enqueue first item on current-thread(synchronously).
   /// From then, using specified queue.
-  public static func startsFromCurrentThread(and queue: TargetQueue) -> TargetQueue {
+  public static func startsFromCurrentThread(andUse queue: TargetQueue) -> TargetQueue {
 
     let numberEnqueued = VergeConcurrency.AtomicReference.init(initialValue: false)
 

--- a/Tests/VergeStoreTests/VergeStoreTests.swift
+++ b/Tests/VergeStoreTests/VergeStoreTests.swift
@@ -622,7 +622,7 @@ final class VergeStoreTests: XCTestCase {
 
     DispatchQueue.global().async {
 
-      let cancellable = store1.sinkState(queue: .startsFromCurrentThread(and: .main)) { state in
+      let cancellable = store1.sinkState(queue: .startsFromCurrentThread(andUse: .mainIsolated())) { state in
 
         defer {
           count += 1

--- a/Tests/VergeStoreTests/VergeStoreTests.swift
+++ b/Tests/VergeStoreTests/VergeStoreTests.swift
@@ -612,5 +612,40 @@ final class VergeStoreTests: XCTestCase {
     withExtendedLifetime(cancellable) {}
 
   }
+
+  func testTargetQueue() {
+
+    let store1 = DemoStore()
+
+    let exp = expectation(description: "11")
+    var count = 0
+
+    DispatchQueue.global().async {
+
+      let cancellable = store1.sinkState(queue: .startsFromCurrentThread(and: .main)) { state in
+
+        defer {
+          count += 1
+        }
+
+        if count == 0 {
+          XCTAssertEqual(Thread.isMainThread, false)
+        } else {
+          XCTAssertEqual(Thread.isMainThread, true)
+          exp.fulfill()
+        }
+
+      }
+
+      store1.commit {
+        $0.count = 10
+      }
+
+      withExtendedLifetime(cancellable) {}
+    }
+
+    wait(for: [exp], timeout: 1)
+
+  }
   
 }


### PR DESCRIPTION
`sinkState` and `sinkValue` uses `.main` in queue parameter as a default.
`.main` emits the events as possible synchronously if these come from main-queue.
In order to do this synchronously, it requires enqueuing events is zero.
However, `.main` is a shared-instance, the events dispatch to the main queue asynchronously.

`sink`'s use-cases are mostly UI binding, it's probably unuseful dispatching the first event asynchronously while building UI.
It might cause several glitches and meaningless blank states.

So, we change the default parameter to `.mainIsolated()`.
with this, each sink method receives the events synchronously if it's possible.
At least, the first event would be delivered synchronously.


One more thing,
This PR includes a new factory method in TargetQueue.
Which is `TargetQueue.startsFromCurrentThread(andUse: )`
This enables to receive the first event on the current-thread which started sink.
From then it receives on specified TargetQueue.

This might cover all of the use-cases for building UI.
In UIKit, you would start sink on main-queue, In Texture you can start sink on any-queue but it's better to get the first event on the current-thread.

