### PR TITLE
Drop receive changes itself in Store, Dispatcher

### DIFF
--- a/Sources/VergeStore/Store/DispatcherBase.swift
+++ b/Sources/VergeStore/Store/DispatcherBase.swift
@@ -39,8 +39,6 @@ open class ScopedDispatcherBase<State, Activity, Scope>: DispatcherType {
   public var rootState: Changes<State> {
     return store.state
   }
-
-  private var sinkCancellable: VergeAnyCancellable?
    
   private var logger: StoreLogger? {
     store.logger
@@ -56,19 +54,8 @@ open class ScopedDispatcherBase<State, Activity, Scope>: DispatcherType {
     let log = DidCreateDispatcherLog(store: targetStore, dispatcher: self)    
     logger?.didCreateDispatcher(log: log, sender: self)
 
-    sinkCancellable = store.sinkState { [weak self] state in
-      self?.receive(state: state.map { $0[keyPath: scope] })
-    }
-
   }
 
-  /**
-   Handles a updated state
-   */
-  open func receive(state: Changes<Scope>) {
-
-  }
-     
   deinit {
     let log = DidDestroyDispatcherLog(store: store, dispatcher: self)
     logger?.didDestroyDispatcher(log: log, sender: self)

--- a/Sources/VergeStore/Store/Store.swift
+++ b/Sources/VergeStore/Store/Store.swift
@@ -118,8 +118,6 @@ open class Store<State, Activity>: _VergeObservableObjectBase, CustomReflectable
   let derivedCache2 = VergeConcurrency.RecursiveLockAtomic(NSMapTable<NSString, AnyObject>.strongToWeakObjects())
   
   public private(set) var logger: StoreLogger?
-
-  private var sinkCancellable: VergeAnyCancellable? = nil
     
   /// An initializer
   /// - Parameters:
@@ -140,18 +138,6 @@ open class Store<State, Activity>: _VergeObservableObjectBase, CustomReflectable
     self.logger = logger
 
     super.init()
-
-    sinkCancellable = sinkState { [weak self] state in
-      self?.receive(state: state)
-    }
-
-  }
-
-  /**
-   Handles a updated state
-   */
-  open func receive(state: Changes<State>) {
-
   }
 
   /// Receives mutation


### PR DESCRIPTION
- Drop it to save performance.
- Because, Use-cases are not so much