### PR TITLE
Update how Derived retain itself to publish the value

### DIFF
--- a/Sources/VergeStore/Store/Derived.swift
+++ b/Sources/VergeStore/Store/Derived.swift
@@ -180,16 +180,13 @@ public class Derived<Value>: _VergeObservableObjectBase, DerivedType {
     dropsFirst: Bool = false,
     queue: TargetQueue = .mainIsolated(),
     receive: @escaping (Changes<Value>) -> Void
-  ) -> VergeAnyCancellable {
-    
+  ) -> VergeAnyCancellable {    
     innerStore.sinkState(
       dropsFirst: dropsFirst,
-      queue: queue
-    ) { (changes) in
-      withExtendedLifetime(self) {}
-      receive(changes)
-    }
-    .asAutoCancellable()
+      queue: queue,
+      receive: receive
+    )
+    .associate(self)
   }
 
   /// Subscribe the state changes
@@ -207,7 +204,13 @@ public class Derived<Value>: _VergeObservableObjectBase, DerivedType {
     queue: TargetQueue = .mainIsolated(),
     receive: @escaping (Changes<Value>, Accumulate) -> Void
   ) -> VergeAnyCancellable {
-    innerStore.sinkState(scan: scan, dropsFirst: dropsFirst, queue: queue, receive: receive)
+    innerStore.sinkState(
+      scan: scan,
+      dropsFirst: dropsFirst,
+      queue: queue,
+      receive: receive
+    )
+    .associate(self)
   }
 
   fileprivate func _makeChain<NewState>(


### PR DESCRIPTION
No changes in behavior:
- To keep receiving value from chained derived, retain cancellable.
- Currently, the closure captures itself.
- And from now, associating with cancellable.

With this, the Xcode memory debugger would analyze correctly.