### PR TITLE
Update methods of Changes that become to use Comparer instead of closure

### DIFF
--- a/Sources/Verge/Store/Changes+Deprecated.swift
+++ b/Sources/Verge/Store/Changes+Deprecated.swift
@@ -1,10 +1,23 @@
 //
-//  Changes+Deprecated.swift
-//  Verge
+// Copyright (c) 2020 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
 //
-//  Created by Muukii on 2020/12/22.
-//  Copyright © 2020 muukii. All rights reserved.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 import Foundation
 

--- a/Sources/Verge/Store/Changes+Deprecated.swift
+++ b/Sources/Verge/Store/Changes+Deprecated.swift
@@ -1,0 +1,103 @@
+//
+//  Changes+Deprecated.swift
+//  Verge
+//
+//  Created by Muukii on 2020/12/22.
+//  Copyright © 2020 muukii. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Deprecates
+
+extension Changes {
+
+  @available(*, deprecated, message: "Create Comparer instead using closure")
+  @inline(__always)
+  public func ifChanged<Composed, Result>(
+    _ compose: (Changes) -> Composed,
+    _ compare: @escaping (Composed, Composed) -> Bool,
+    _ perform: (Composed) throws -> Result
+  ) rethrows -> Result? {
+    guard let result = takeIfChanged(compose, compare) else {
+      return nil
+    }
+
+    return try perform(result)
+  }
+
+  /// Takes a composed value if it's changed from old value.
+  @available(*, deprecated, message: "Create Comparer instead using closure")
+  @inline(__always)
+  public func takeIfChanged<T>(
+    _ keyPath: ChangesKeyPath<T>,
+    _ compare: @escaping (T, T) -> Bool
+  ) -> T? {
+    takeIfChanged({ $0[keyPath: keyPath] }, .init(compare))
+  }
+
+  @available(*, deprecated, message: "Create Comparer instead using closure")
+  @inline(__always)
+  public func hasChanges<Composed>(
+    _ compose: (Changes) -> Composed,
+    _ compare: @escaping (Composed, Composed) -> Bool
+  ) -> Bool {
+    hasChanges(compose, .init(compare))
+  }
+
+  /// Returns boolean that indicates value specified by keyPath contains changes with compared old and new.
+  @available(*, deprecated, message: "Create Comparer instead using closure")
+  @inline(__always)
+  public func hasChanges<T>(
+    _ keyPath: ChangesKeyPath<T>,
+    _ compare: @escaping (T, T) -> Bool
+  ) -> Bool {
+    hasChanges({ $0[keyPath: keyPath] }, compare)
+  }
+
+  /// Returns boolean that indicates value specified by keyPath contains **NO** changes with compared old and new.
+  @available(*, deprecated, message: "Create Comparer instead using closure")
+  @inline(__always)
+  public func noChanges<T>(_ keyPath: ChangesKeyPath<T>, _ compare: @escaping (T, T) -> Bool) -> Bool {
+    !hasChanges(keyPath, .init(compare))
+  }
+
+  /// Takes a composed value if it's changed from old value.
+  @available(*, deprecated, message: "Create Comparer instead using closure")
+  @inline(__always)
+  public func takeIfChanged<Composed>(
+    _ compose: (Changes) throws -> Composed,
+    _ compare: @escaping (Composed, Composed) -> Bool
+  ) rethrows -> Composed? {
+
+    try takeIfChanged(compose, .init(compare))
+  }
+
+  /// Do a closure if value specified by keyPath contains changes.
+  @available(*, deprecated, message: "Create Comparer instead using closure")
+  public func ifChanged<T, Result>(
+    _ selector: ChangesKeyPath<T>,
+    _ compare: @escaping (T, T) -> Bool,
+    _ perform: (T) throws -> Result
+  ) rethrows -> Result? {
+    try ifChanged(selector, .init(compare), perform)
+  }
+
+  @inline(__always)
+  @available(*, deprecated, renamed: "ifChanged(_:_:_:)")
+  public func ifChanged<Composed, Result>(
+    compose: (Changes) -> Composed,
+    comparer: @escaping (Composed, Composed) -> Bool,
+    perform: (Composed) throws -> Result
+  ) rethrows -> Result? {
+    try ifChanged(compose, comparer, perform)
+  }
+
+  @available(*, deprecated, renamed: "ifChanged(_:_:)")
+  public func ifChanged<Composed: Equatable, Result>(
+    compose: (Changes) -> Composed,
+    perform: (Composed) throws -> Result
+  ) rethrows -> Result? {
+    try ifChanged(compose, perform)
+  }
+}

--- a/Sources/Verge/Store/Changes.swift
+++ b/Sources/Verge/Store/Changes.swift
@@ -230,7 +230,7 @@ extension Changes {
   @inline(__always)
   public func takeIfChanged<Composed>(
     _ compose: (Changes) throws -> Composed,
-    _ compare: (Composed, Composed) throws -> Bool
+    _ comparer: Comparer<Composed>
   ) rethrows -> Composed? {
     let signpost = VergeSignpostTransaction("Changes.takeIfChanged(compose:comparer:)")
     defer {
@@ -244,9 +244,10 @@ extension Changes {
     }
 
     let old = previousValue
+    let compare = comparer.curried()
 
     let composedFromCurrent = try compose(current)
-    guard try !compare(compose(old), composedFromCurrent) else {
+    guard !compare(try compose(old), composedFromCurrent) else {
       return nil
     }
 
@@ -264,7 +265,7 @@ extension Changes {
   @inline(__always)
   public func ifChanged<Composed, Result>(
     _ compose: (Changes) -> Composed,
-    _ comparer: (Composed, Composed) -> Bool,
+    _ comparer: Comparer<Composed>,
     _ perform: (Composed) throws -> Result
   ) rethrows -> Result? {
     guard let result = takeIfChanged(compose, comparer) else {
@@ -283,84 +284,27 @@ extension Changes {
   public func takeIfChanged<Composed: Equatable>(
     _ compose: (Changes) throws -> Composed
   ) rethrows -> Composed? {
-    try takeIfChanged(compose, ==)
+    try takeIfChanged(compose, .usingEquatable)
   }
 
-  /// Takes a composed value if it's changed from old value.
-  @inline(__always)
-  public func takeIfChanged<T>(
-    _ keyPath: ChangesKeyPath<T>,
-    _ compare: (T, T) throws -> Bool
-  ) rethrows -> T? {
-    try takeIfChanged({ $0[keyPath: keyPath] }, compare)
-  }
-
-  /// Returns boolean that indicates value specified by keyPath contains **NO** changes with compared old and new.
-  @inline(__always)
-  public func noChanges<T: Equatable>(_ keyPath: ChangesKeyPath<T>) -> Bool {
-    !hasChanges(keyPath, ==)
-  }
-
-  /// Returns boolean that indicates value specified by keyPath contains **NO** changes with compared old and new.
-  @inline(__always)
-  public func noChanges<T>(_ keyPath: ChangesKeyPath<T>, _ compare: (T, T) -> Bool) -> Bool {
-    !hasChanges(keyPath, compare)
-  }
-
-  /// Returns boolean that indicates value specified by keyPath contains **NO** changes with compared old and new.
-  @inline(__always)
-  public func noChanges<T>(_ keyPath: ChangesKeyPath<T>, _ comparer: Comparer<T>) -> Bool {
-    !hasChanges(keyPath, comparer.equals)
-  }
-
-  /// Returns boolean that indicates value specified by keyPath contains changes with compared old and new.
-  @inline(__always)
-  public func hasChanges<T: Equatable>(_ keyPath: ChangesKeyPath<T>) -> Bool {
-    hasChanges(keyPath, ==)
-  }
-
-  /// Returns boolean that indicates value specified by keyPath contains changes with compared old and new.
-  @inline(__always)
-  public func hasChanges<T>(_ keyPath: ChangesKeyPath<T>, _ comparer: Comparer<T>) -> Bool {
-    hasChanges(keyPath, comparer.equals)
-  }
-
-  /// Returns boolean that indicates value specified by keyPath contains changes with compared old and new.
-  @inline(__always)
-  public func hasChanges<T>(_ keyPath: ChangesKeyPath<T>, _ compare: (T, T) -> Bool) -> Bool {
-    hasChanges({ $0[keyPath: keyPath] }, compare)
-  }
-
-  @inline(__always)
-  public func hasChanges<Composed: Equatable>(
-    _ compose: (Changes) -> Composed
-  ) -> Bool {
-    hasChanges(compose, ==)
-  }
-
-  @inline(__always)
-  public func hasChanges<Composed>(
-    _ compose: (Changes) -> Composed,
-    _ compare: (Composed, Composed) -> Bool
-  ) -> Bool {
-    takeIfChanged(compose, compare) != nil
-  }
 
   /// Do a closure if value specified by keyPath contains changes.
   public func ifChanged<T, Result>(
     _ selector: ChangesKeyPath<T>,
-    _ comparer: (T, T) -> Bool,
+    _ comparer: Comparer<T>,
     _ perform: (T) throws -> Result
   ) rethrows -> Result? {
-    guard hasChanges(selector, comparer) else { return nil }
-    return try perform(self[keyPath: selector])
+    guard let value = takeIfChanged({ $0[keyPath: selector] }, comparer) else {
+      return nil
+    }
+    return try perform(value)
   }
 
   public func ifChanged<Composed: Equatable, Result>(
     _ compose: (Changes) -> Composed,
     _ perform: (Composed) throws -> Result
   ) rethrows -> Result? {
-    try ifChanged(compose, ==, perform)
+    try ifChanged(compose, .usingEquatable, perform)
   }
 
   /// Do a closure if value specified by keyPath contains changes.
@@ -369,7 +313,7 @@ extension Changes {
     _ keyPath: ChangesKeyPath<T>,
     _ perform: (T) throws -> Result
   ) rethrows -> Result? {
-    try ifChanged(keyPath, ==, perform)
+    try ifChanged(keyPath, .usingEquatable, perform)
   }
 
   @inline(__always)
@@ -378,7 +322,7 @@ extension Changes {
     _ keyPath1: ChangesKeyPath<T1>,
     _ perform: ((T0, T1)) throws -> Result
   ) rethrows -> Result? {
-    try ifChanged({ ($0[keyPath: keyPath0], $0[keyPath: keyPath1]) }, ==, perform)
+    try ifChanged({ ($0[keyPath: keyPath0], $0[keyPath: keyPath1]) }, .init(==), perform)
   }
 
   @inline(__always)
@@ -390,7 +334,7 @@ extension Changes {
   ) rethrows -> Result? {
     try ifChanged(
       { ($0[keyPath: keyPath0], $0[keyPath: keyPath1], $0[keyPath: keyPath2]) },
-      ==,
+      .init(==),
       perform
     )
   }
@@ -411,7 +355,7 @@ extension Changes {
           $0[keyPath: keyPath2],
           $0[keyPath: keyPath3]
         ) },
-      ==,
+      .init(==),
       perform
     )
   }
@@ -440,31 +384,60 @@ extension Changes {
         $0[keyPath: keyPath3],
         $0[keyPath: keyPath4]
       ) },
-      ==,
+      .init(==),
       perform
     )
   }
 }
 
-// MARK: - Deprecates
+// MARK: - Has changes
 
 extension Changes {
+  /// Returns boolean that indicates value specified by keyPath contains changes with compared old and new.
   @inline(__always)
-  @available(*, deprecated, renamed: "ifChanged(_:_:_:)")
-  public func ifChanged<Composed, Result>(
-    compose: (Changes) -> Composed,
-    comparer: (Composed, Composed) -> Bool,
-    perform: (Composed) throws -> Result
-  ) rethrows -> Result? {
-    try ifChanged(compose, comparer, perform)
+  public func hasChanges<T: Equatable>(_ keyPath: ChangesKeyPath<T>) -> Bool {
+    hasChanges(keyPath, .usingEquatable)
   }
 
-  @available(*, deprecated, renamed: "ifChanged(_:_:)")
-  public func ifChanged<Composed: Equatable, Result>(
-    compose: (Changes) -> Composed,
-    perform: (Composed) throws -> Result
-  ) rethrows -> Result? {
-    try ifChanged(compose, perform)
+  /// Returns boolean that indicates value specified by keyPath contains changes with compared old and new.
+  @inline(__always)
+  public func hasChanges<T>(
+    _ keyPath: ChangesKeyPath<T>,
+    _ comparer: Comparer<T>
+  ) -> Bool {
+    hasChanges({ $0[keyPath: keyPath] }, comparer)
+  }
+
+  @inline(__always)
+  public func hasChanges<Composed: Equatable>(
+    _ compose: (Changes) -> Composed
+  ) -> Bool {
+    hasChanges(compose, .usingEquatable)
+  }
+
+  @inline(__always)
+  public func hasChanges<Composed>(
+    _ compose: (Changes) -> Composed,
+    _ comparer: Comparer<Composed>
+  ) -> Bool {
+    takeIfChanged(compose, comparer) != nil
+  }
+
+}
+
+// MARK: - NoChanges
+
+extension Changes {
+  /// Returns boolean that indicates value specified by keyPath contains **NO** changes with compared old and new.
+  @inline(__always)
+  public func noChanges<T: Equatable>(_ keyPath: ChangesKeyPath<T>) -> Bool {
+    !hasChanges(keyPath, .usingEquatable)
+  }
+
+  /// Returns boolean that indicates value specified by keyPath contains **NO** changes with compared old and new.
+  @inline(__always)
+  public func noChanges<T>(_ keyPath: ChangesKeyPath<T>, _ comparer: Comparer<T>) -> Bool {
+    !hasChanges(keyPath, comparer)
   }
 }
 
@@ -476,8 +449,8 @@ extension Changes: CustomReflectable {
         "version": version,
         "previous": previous as Any,
         "primitive": primitive,
-        "mutation": mutation,
-        "modification": modification,
+        "mutation": mutation as Any,
+        "modification": modification as Any,
       ],
       displayStyle: .struct,
       ancestorRepresentation: .generated

--- a/Sources/Verge/Store/Changes.swift
+++ b/Sources/Verge/Store/Changes.swift
@@ -226,6 +226,7 @@ public final class Changes<Value>: ChangesType, Equatable {
 // MARK: - Primitive methods
 
 extension Changes {
+  
   /// Takes a composed value if it's changed from old value.
   @inline(__always)
   public func takeIfChanged<Composed>(
@@ -254,11 +255,11 @@ extension Changes {
     return composedFromCurrent
   }
 
-  /// Performs closure if the composed value changed
+  /// Performs a closure if the selected value changed from the previous one.
   ///
   /// - Parameters:
   ///   - compose: A closure that projects a composed value from self. that executes with both of value(new and old).
-  ///   - comparer: A closure that checks if the composed values are different between current and old.
+  ///   - comparer: A Comparer that checks if the composed values are different between current and old.
   ///   - perform: A closure that executes any operation if composed value changed.
   ///
   /// - Returns: An instance that returned from the perform closure if performed.
@@ -287,8 +288,9 @@ extension Changes {
     try takeIfChanged(compose, .usingEquatable)
   }
 
-
-  /// Do a closure if value specified by keyPath contains changes.
+  /**
+   Performs a closure if the selected value changed from the previous one.
+   */
   public func ifChanged<T, Result>(
     _ selector: ChangesKeyPath<T>,
     _ comparer: Comparer<T>,
@@ -300,6 +302,9 @@ extension Changes {
     return try perform(value)
   }
 
+  /**
+   Performs a closure if the selected value changed from the previous one.
+   */
   public func ifChanged<Composed: Equatable, Result>(
     _ compose: (Changes) -> Composed,
     _ perform: (Composed) throws -> Result
@@ -307,7 +312,9 @@ extension Changes {
     try ifChanged(compose, .usingEquatable, perform)
   }
 
-  /// Do a closure if value specified by keyPath contains changes.
+  /**
+   Performs a closure if the selected value changed from the previous one.
+   */
   @inline(__always)
   public func ifChanged<T: Equatable, Result>(
     _ keyPath: ChangesKeyPath<T>,
@@ -316,6 +323,10 @@ extension Changes {
     try ifChanged(keyPath, .usingEquatable, perform)
   }
 
+  /**
+   Performs a closure if the selected value changed from the previous one.
+   Selected multiple value would be packed as tuple.
+   */
   @inline(__always)
   public func ifChanged<T0: Equatable, T1: Equatable, Result>(
     _ keyPath0: ChangesKeyPath<T0>,
@@ -325,6 +336,10 @@ extension Changes {
     try ifChanged({ ($0[keyPath: keyPath0], $0[keyPath: keyPath1]) }, .init(==), perform)
   }
 
+  /**
+   Performs a closure if the selected value changed from the previous one.
+   Selected multiple value would be packed as tuple.
+   */
   @inline(__always)
   public func ifChanged<T0: Equatable, T1: Equatable, T2: Equatable, Result>(
     _ keyPath0: ChangesKeyPath<T0>,
@@ -339,6 +354,10 @@ extension Changes {
     )
   }
 
+  /**
+   Performs a closure if the selected value changed from the previous one.
+   Selected multiple value would be packed as tuple.
+   */
   @inline(__always)
   public func ifChanged<T0: Equatable, T1: Equatable, T2: Equatable, T3: Equatable, Result>(
     _ keyPath0: ChangesKeyPath<T0>,
@@ -360,6 +379,10 @@ extension Changes {
     )
   }
 
+  /**
+   Performs a closure if the selected value changed from the previous one.
+   Selected multiple value would be packed as tuple.
+   */
   @inline(__always)
   public func ifChanged<
     T0: Equatable,

--- a/Sources/Verge/Store/Comparer.swift
+++ b/Sources/Verge/Store/Comparer.swift
@@ -102,6 +102,10 @@ extension Comparer where Input : Equatable {
   public init() {
     self.init(==)
   }
+
+  public static var usingEquatable: Self {
+    return .init(==)
+  }
 }
 
 extension Comparer {

--- a/Sources/Verge/Store/MemoizeMap.swift
+++ b/Sources/Verge/Store/MemoizeMap.swift
@@ -241,7 +241,7 @@ extension MemoizeMap where Input : ChangesType {
         compute(derive(input.asChanges()))
     }) { input in
 
-      let result = input.asChanges().ifChanged(derive, dropsDerived) { (derived) in
+      let result = input.asChanges().ifChanged(derive, .init(dropsDerived)) { (derived) in
         compute(derived)
       }
 

--- a/Sources/VergeORM/Derived+ORM.swift
+++ b/Sources/VergeORM/Derived+ORM.swift
@@ -133,7 +133,7 @@ extension MemoizeMap where Input : ChangesType, Input.Value : DatabaseEmbedding 
           { (composing) -> Input.Value.Database in
             let db = path(composing.root)
             return db
-        }, noChangesComparer.curried()
+        }, noChangesComparer
         )
         
         guard hasChanges else {
@@ -226,7 +226,7 @@ extension StoreType where State : DatabaseEmbedding {
     let d = underlyingDerived.chain(
       .init(map: { $0.root }),
       dropsOutput: { changes in
-        changes.noChanges(\.root, {
+        changes.noChanges(\.root, .init {
           dropsOutput($0.wrapped, $1.wrapped)
         })
       },
@@ -654,7 +654,7 @@ extension StoreType where State : DatabaseEmbedding {
 
         let changes = state.asChanges()
 
-        guard changes.hasChanges({ path($0.primitive) }, noChangesComparer.curried()) else {
+        guard changes.hasChanges({ path($0.primitive) }, noChangesComparer) else {
           return .noChanages
         }
 
@@ -669,7 +669,7 @@ extension StoreType where State : DatabaseEmbedding {
 
           return result
 
-        }, ==)
+        }, .init(==))
 
         guard let derivedArray = _derivedArray else {
           return .noChanages

--- a/Sources/VergeRx/Store+Rx.swift
+++ b/Sources/VergeRx/Store+Rx.swift
@@ -147,7 +147,7 @@ extension ObservableType where Element : ChangesType {
   public func changed<S>(_ selector: @escaping (Changes<Element.Value>) -> S, _ compare: @escaping (S, S) -> Bool) -> Observable<S> {
     
     return flatMap { changes -> Observable<S> in
-      let _r = changes.asChanges().ifChanged(selector, compare) { value in
+      let _r = changes.asChanges().ifChanged(selector, .init(compare)) { value in
         return value
       }
       return _r.map { .just($0) } ?? .empty()

--- a/Tests/VergeTests/ComputedTests.swift
+++ b/Tests/VergeTests/ComputedTests.swift
@@ -264,7 +264,7 @@ class Computed2Tests: XCTestCase {
     
     var count = 0
         
-    store.state.ifChanged({ $0.computed.num_0 }, ==) { v in
+    store.state.ifChanged({ $0.computed.num_0 }, .init(==)) { v in
         count += 1
     }
     
@@ -272,7 +272,7 @@ class Computed2Tests: XCTestCase {
       $0.num_0 = 0
     }
     
-    store.state.ifChanged({ $0.computed.num_0 }, ==) { v in
+    store.state.ifChanged({ $0.computed.num_0 }, .init(==)) { v in
         count += 1
     }
     
@@ -295,7 +295,7 @@ class Computed2Tests: XCTestCase {
             $0.computed.num_0
           )
       },
-        ==) { _ in
+        .init(==)) { _ in
           perform()
       }
     }

--- a/Tests/VergeTests/SyntaxTests.swift
+++ b/Tests/VergeTests/SyntaxTests.swift
@@ -20,7 +20,7 @@ enum SyntaxTests {
 
     }
 
-    changes.ifChanged(\.nonEquatable, { _, _ in false }) { name in
+    changes.ifChanged(\.nonEquatable, .alwaysFalse) { name in
 
     }
 

--- a/Verge.xcodeproj/project.pbxproj
+++ b/Verge.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		4BDBDFA423CE0DD100EEA112 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 4BDBDFA323CE0DD100EEA112 /* RxCocoa */; };
 		4BDBDFA623CE0DD100EEA112 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 4BDBDFA523CE0DD100EEA112 /* RxSwift */; };
 		4BE33C6924875CD800F3F2C6 /* _COWFragment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE33C6824875CD800F3F2C6 /* _COWFragment.swift */; };
+		4BEA328D2591B61A0009A2DF /* Changes+Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BEA328C2591B61A0009A2DF /* Changes+Deprecated.swift */; };
 		4BF21F302458C1860045B5C2 /* UtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF21F2F2458C1860045B5C2 /* UtilTests.swift */; };
 		4BF2BCCE238A658400F70CDA /* VergeClassic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B86A4861F969AD5002D54FE /* VergeClassic.framework */; };
 		4BF3C2EC242093AC006B1726 /* MultithreadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF3C2EA24209324006B1726 /* MultithreadingTests.swift */; };
@@ -365,6 +366,7 @@
 		4BDB78212447934A00675D03 /* StoreWrapperType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreWrapperType.swift; sourceTree = "<group>"; };
 		4BE33C6824875CD800F3F2C6 /* _COWFragment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _COWFragment.swift; sourceTree = "<group>"; };
 		4BE9455A23AD1BBB0060F977 /* EventEmitterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventEmitterTests.swift; sourceTree = "<group>"; };
+		4BEA328C2591B61A0009A2DF /* Changes+Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Changes+Deprecated.swift"; sourceTree = "<group>"; };
 		4BF21F2F2458C1860045B5C2 /* UtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilTests.swift; sourceTree = "<group>"; };
 		4BF2BCD5238A68CE00F70CDA /* ViewModelBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelBase.swift; sourceTree = "<group>"; };
 		4BF2BCD9238A7B6900F70CDA /* EventEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventEmitter.swift; sourceTree = "<group>"; };
@@ -738,6 +740,7 @@
 				4BCBCA8A2381C82100F33B15 /* DispatcherBase.swift */,
 				4B68394F237062F7002FFC5A /* StateType.swift */,
 				4BBFF45D24389D3D005BA03C /* Changes.swift */,
+				4BEA328C2591B61A0009A2DF /* Changes+Deprecated.swift */,
 				4B6B77AA243FA3EB00E0C0EA /* _StateTypeContainer.swift */,
 				4B3834DE248235AD008A0B47 /* _VergeObservableObjectBase.swift */,
 				4B8EB4F823C034A900035B2A /* Comparer.swift */,
@@ -1318,6 +1321,7 @@
 				4BCBCA8B2381C82100F33B15 /* DispatcherBase.swift in Sources */,
 				4B98257A254589960040B377 /* BatchCommit.swift in Sources */,
 				4BDBDF6A23CE027D00EEA112 /* ViewModelBase.swift in Sources */,
+				4BEA328D2591B61A0009A2DF /* Changes+Deprecated.swift in Sources */,
 				4B04C5622570875200731802 /* VergeConcurrency+SynchronizationTracker.swift in Sources */,
 				4BD260A5245C7F680052B4AC /* Derived+Assign.swift in Sources */,
 				4B2050F723D5C841000A2779 /* StoreLogger.swift in Sources */,


### PR DESCRIPTION
Verge provides `Comparer<T>` value type that enables us to describe how we compare values.
Differ with describing closure, we could add something factory methods to create easily and making portability.