### PR TITLE
Add Sink method to DispatcherType

### DIFF
--- a/Sources/Verge/Store/DispatcherType.swift
+++ b/Sources/Verge/Store/DispatcherType.swift
@@ -22,23 +22,42 @@
 import Foundation
 
 public protocol DispatcherType {
-    
   associatedtype WrappedStore: StoreType
   associatedtype Scope = WrappedStore.State
-    
+
   var store: WrappedStore { get }
   var scope: WritableKeyPath<WrappedStore.State, Scope> { get }
-  
 }
 
 extension DispatcherType where Scope == WrappedStore.State {
-  
-   public var scope: WritableKeyPath<WrappedStore.State, WrappedStore.State> { \WrappedStore.State.self }
-  
+  public var scope: WritableKeyPath<WrappedStore.State, WrappedStore.State> {
+    \WrappedStore.State.self
+  }
 }
 
 extension DispatcherType {
-  
+  /**
+    Subscribe the state that scoped
+
+    First object always returns true from ifChanged / hasChanges / noChanges unless dropsFirst is true.
+
+    - Parameters:
+      - dropsFirst: Drops the latest value on started. if true, receive closure will call from next state updated.
+      - queue: Specify a queue to receive changes object.
+    - Returns: A subscriber that performs the provided closure upon receiving values.
+   */
+  public func sinkState(
+    dropsFirst: Bool = false,
+    queue: TargetQueue = .mainIsolated(),
+    receive: @escaping (Changes<Scope>) -> Void
+  ) -> VergeAnyCancellable {
+    let _scope = scope
+
+    return store.asStore().sinkState(dropsFirst: dropsFirst, queue: queue) { state in
+      receive(state.map { $0[keyPath: _scope] })
+    }
+  }
+
   /// Send activity
   /// - Parameter activity:
   public func send(
@@ -54,10 +73,10 @@ extension DispatcherType {
       function: function.description,
       line: line
     )
-    
+
     store.asStore()._send(activity: activity, trace: trace)
   }
-        
+
   /// Send activity
   /// - Parameter activity:
   public func send(
@@ -68,7 +87,7 @@ extension DispatcherType {
   ) {
     send("", activity, file, function, line)
   }
-        
+
   /// Run Mutation that created inline
   ///
   /// Throwable
@@ -79,18 +98,17 @@ extension DispatcherType {
     _ line: UInt = #line,
     mutation: (inout InoutRef<Scope>) throws -> Result
   ) rethrows -> Result {
-    
     let trace = MutationTrace(
       name: name,
       file: file,
       function: function,
       line: line
     )
-    
+
     return try store.asStore()._receive(
       mutation: { state -> Result in
         try state.map(keyPath: scope) { (ref: inout InoutRef<Scope>) -> Result in
-          return try mutation(&ref)
+          try mutation(&ref)
         }
       },
       trace: trace
@@ -107,7 +125,6 @@ extension DispatcherType {
     _ line: UInt = #line,
     mutation: (inout InoutRef<Scope>) throws -> Result
   ) rethrows -> Result where Scope == WrappedStore.State {
-
     let trace = MutationTrace(
       name: name,
       file: file,
@@ -122,7 +139,7 @@ extension DispatcherType {
       trace: trace
     )
   }
-      
+
   /// Run Mutation that created inline
   ///
   /// Throwable
@@ -134,24 +151,22 @@ extension DispatcherType {
     scope: WritableKeyPath<WrappedStore.State, NewScope>,
     mutation: (inout InoutRef<NewScope>) throws -> Result
   ) rethrows -> Result {
-    
     let trace = MutationTrace(
       name: name,
       file: file,
       function: function,
       line: line
     )
-    
+
     return try store.asStore()._receive(
       mutation: { state -> Result in
         try state.map(keyPath: scope) { (ref: inout InoutRef<NewScope>) -> Result in
-          return try mutation(&ref)
+          try mutation(&ref)
         }
-    },
+      },
       trace: trace
     )
   }
-
 
   /// Run Mutation that created inline
   ///
@@ -164,7 +179,6 @@ extension DispatcherType {
     scope: WritableKeyPath<WrappedStore.State, NewScope?>,
     mutation: (inout InoutRef<NewScope>?) throws -> Result
   ) rethrows -> Result {
-
     let trace = MutationTrace(
       name: name,
       file: file,
@@ -175,19 +189,20 @@ extension DispatcherType {
     return try store.asStore()._receive(
       mutation: { state -> Result in
         try state.map(keyPath: scope) { (ref: inout InoutRef<NewScope>?) -> Result in
-          return try mutation(&ref)
+          try mutation(&ref)
         }
       },
       trace: trace
     )
   }
-  
-  public func detached<NewScope>(from newScope: WritableKeyPath<WrappedStore.State, NewScope>) -> DetachedDispatcher<WrappedStore.State, WrappedStore.Activity, NewScope> {
+
+  public func detached<NewScope>(from newScope: WritableKeyPath<WrappedStore.State, NewScope>)
+  -> DetachedDispatcher<WrappedStore.State, WrappedStore.Activity, NewScope> {
     .init(targetStore: store.asStore(), scope: newScope)
   }
-  
-  public func detached<NewScope>(by appendingScope: WritableKeyPath<Scope, NewScope>) -> DetachedDispatcher<WrappedStore.State, WrappedStore.Activity, NewScope> {
-    .init(targetStore: store.asStore(), scope: self.scope.appending(path: appendingScope))
+
+  public func detached<NewScope>(by appendingScope: WritableKeyPath<Scope, NewScope>)
+  -> DetachedDispatcher<WrappedStore.State, WrappedStore.Activity, NewScope> {
+    .init(targetStore: store.asStore(), scope: scope.appending(path: appendingScope))
   }
-    
 }

--- a/Sources/Verge/Store/Store.swift
+++ b/Sources/Verge/Store/Store.swift
@@ -25,8 +25,48 @@ import Foundation
 import Combine
 #endif
 
+public protocol SinkProviding: AnyObject {
+
+  associatedtype State
+
+  func sinkState(
+  dropsFirst: Bool,
+  queue: TargetQueue,
+  receive: @escaping (Changes<State>) -> Void
+  ) -> VergeAnyCancellable
+
+}
+
+extension SinkProviding {
+
+  /// Subscribe the state changes
+  ///
+  /// First object always returns true from ifChanged / hasChanges / noChanges unless dropsFirst is true.
+  ///
+  /// - Parameters:
+  ///   - scan: Accumulates a specified type of value over receiving updates.
+  ///   - dropsFirst: Drops the latest value on started. if true, receive closure will call from next state updated.
+  ///   - queue: Specify a queue to receive changes object.
+  /// - Returns: A subscriber that performs the provided closure upon receiving values.
+  public func sinkState<Accumulate>(
+    scan: Scan<Changes<State>, Accumulate>,
+    dropsFirst: Bool = false,
+    queue: TargetQueue = .mainIsolated(),
+    receive: @escaping (Changes<State>, Accumulate) -> Void
+  ) -> VergeAnyCancellable {
+
+    sinkState(dropsFirst: dropsFirst, queue: queue) { (changes) in
+
+      let accumulate = scan.accumulate(changes)
+      receive(changes, accumulate)
+    }
+
+  }
+  
+}
+
 /// A protocol that indicates itself is a reference-type and can convert to concrete Store type.
-public protocol StoreType: AnyObject {
+public protocol StoreType: SinkProviding {
   associatedtype State
   associatedtype Activity = Never
   
@@ -258,30 +298,6 @@ open class Store<State, Activity>: _VergeObservableObjectBase, CustomReflectable
     }
 
     return .init(cancellable)
-
-  }
-
-  /// Subscribe the state changes
-  ///
-  /// First object always returns true from ifChanged / hasChanges / noChanges unless dropsFirst is true.
-  ///
-  /// - Parameters:
-  ///   - scan: Accumulates a specified type of value over receiving updates.
-  ///   - dropsFirst: Drops the latest value on started. if true, receive closure will call from next state updated.
-  ///   - queue: Specify a queue to receive changes object.
-  /// - Returns: A subscriber that performs the provided closure upon receiving values.
-  public func sinkState<Accumulate>(
-    scan: Scan<Changes<State>, Accumulate>,
-    dropsFirst: Bool = false,
-    queue: TargetQueue = .mainIsolated(),
-    receive: @escaping (Changes<State>, Accumulate) -> Void
-  ) -> VergeAnyCancellable {
-
-    sinkState(dropsFirst: dropsFirst, queue: queue) { (changes) in
-
-      let accumulate = scan.accumulate(changes)
-      receive(changes, accumulate)
-    }
 
   }
 

--- a/Sources/Verge/Store/StoreWrapperType.swift
+++ b/Sources/Verge/Store/StoreWrapperType.swift
@@ -108,6 +108,24 @@ extension StoreComponentType {
     store.asStore().sinkState(dropsFirst: dropsFirst, queue: queue, receive: receive)
   }
 
+  /// Subscribe the state changes
+  ///
+  /// First object always returns true from ifChanged / hasChanges / noChanges unless dropsFirst is true.
+  ///
+  /// - Parameters:
+  ///   - scan: Accumulates a specified type of value over receiving updates.
+  ///   - dropsFirst: Drops the latest value on started. if true, receive closure will call from next state updated.
+  ///   - queue: Specify a queue to receive changes object.
+  /// - Returns: A subscriber that performs the provided closure upon receiving values.
+  public func sinkState<Accumulate>(
+    scan: Scan<Changes<WrappedStore.State>, Accumulate>,
+    dropsFirst: Bool = false,
+    queue: TargetQueue = .mainIsolated(),
+    receive: @escaping (Changes<WrappedStore.State>, Accumulate) -> Void
+  ) -> VergeAnyCancellable {
+    store.asStore().sinkState(scan: scan, dropsFirst: dropsFirst, queue: queue, receive: receive)
+  }
+  
   /// Subscribe the activity
   ///
   /// - Returns: A subscriber that performs the provided closure upon receiving values.

--- a/Sources/Verge/Store/StoreWrapperType.swift
+++ b/Sources/Verge/Store/StoreWrapperType.swift
@@ -108,24 +108,6 @@ extension StoreComponentType {
     store.asStore().sinkState(dropsFirst: dropsFirst, queue: queue, receive: receive)
   }
 
-  /// Subscribe the state changes
-  ///
-  /// First object always returns true from ifChanged / hasChanges / noChanges unless dropsFirst is true.
-  ///
-  /// - Parameters:
-  ///   - scan: Accumulates a specified type of value over receiving updates.
-  ///   - dropsFirst: Drops the latest value on started. if true, receive closure will call from next state updated.
-  ///   - queue: Specify a queue to receive changes object.
-  /// - Returns: A subscriber that performs the provided closure upon receiving values.
-  public func sinkState<Accumulate>(
-    scan: Scan<Changes<WrappedStore.State>, Accumulate>,
-    dropsFirst: Bool = false,
-    queue: TargetQueue = .mainIsolated(),
-    receive: @escaping (Changes<WrappedStore.State>, Accumulate) -> Void
-  ) -> VergeAnyCancellable {
-    store.asStore().sinkState(scan: scan, dropsFirst: dropsFirst, queue: queue, receive: receive)
-  }
-
   /// Subscribe the activity
   ///
   /// - Returns: A subscriber that performs the provided closure upon receiving values.

--- a/Tests/VergeTests/VergeStoreTests.swift
+++ b/Tests/VergeTests/VergeStoreTests.swift
@@ -491,36 +491,34 @@ final class VergeStoreTests: XCTestCase {
     withExtendedLifetime(sub, {})
     
   }
-  
-  func testAsignee2() {
-    
-    final class DemoStore2: StoreWrapperType {
-      
-      typealias Activity = Never
-      
-      struct State {
-        var source: Changes<Int>
-      }
-      
-      let store: DefaultStore
-      var sub: VergeAnyCancellable? = nil
-      
-      init(sourceStore: DemoStore) {
-        
-        let d = sourceStore
-          .derived(.map(\.count), queue: .passthrough)
-        
-        self.store = .init(initialState: .init(source: d.value), logger: nil)
-        
-        sub = d.assign(to: assignee(\.source))
-        
-      }
+
+  final class DemoStoreWrapper2: StoreWrapperType {
+
+    struct State {
+      var source: Changes<Int>
     }
 
-    
+    let store: DefaultStore
+    var sub: VergeAnyCancellable? = nil
+
+    init(sourceStore: DemoStore) {
+
+      let d = sourceStore
+        .derived(.map(\.count), queue: .passthrough)
+
+      self.store = .init(initialState: .init(source: d.value), logger: nil)
+
+      sub = d.assign(to: assignee(\.source))
+
+    }
+
+  }
+  
+  func testAsignee2() {
+
     let store1 = DemoStore()
-    let store2 = DemoStore2(sourceStore: store1)
-      
+    let store2 = DemoStoreWrapper2(sourceStore: store1)
+
     store1.commit {
       $0.count += 1
     }


### PR DESCRIPTION
DispatcherType gets `sink` methods.
It turns out DispatcherType is like StoreType which does not have a concrete store.

Comparing with CoreData structure:
Store (StoreType) - NSPersistentStore and NSManagedObjectContext
DispathcerType - NSManagedObjectContext

So DispatcherType will rename as `StoreContextType`.

