### PR TITLE
Make EventEmitter delivering event by commit order.

### DIFF
--- a/Sources/Verge/Library/Storage.swift
+++ b/Sources/Verge/Library/Storage.swift
@@ -29,7 +29,7 @@ public protocol _VergeRecursiveLockType {
 }
 
 @discardableResult
-func withLocking<Lock: _VergeRecursiveLockType, Return>(_ lock: Lock, _ performCriticalSession: () -> Return) -> Return {
+func withLocking<Lock: NSLocking, Return>(_ lock: Lock, _ performCriticalSession: () -> Return) -> Return {
   lock.lock()
   defer {
     lock.unlock()

--- a/Sources/Verge/Library/Storage.swift
+++ b/Sources/Verge/Library/Storage.swift
@@ -28,6 +28,14 @@ public protocol _VergeRecursiveLockType {
   init()
 }
 
+func withLocking<Lock: _VergeRecursiveLockType, Return>(_ lock: Lock, _ performCriticalSession: () -> Return) -> Return {
+  lock.lock()
+  defer {
+    lock.unlock()
+  }
+  return performCriticalSession()
+}
+
 extension _VergeRecursiveLockType {
 
   public func asAny() -> VergeAnyRecursiveLock {

--- a/Sources/Verge/Library/Storage.swift
+++ b/Sources/Verge/Library/Storage.swift
@@ -28,6 +28,7 @@ public protocol _VergeRecursiveLockType {
   init()
 }
 
+@discardableResult
 func withLocking<Lock: _VergeRecursiveLockType, Return>(_ lock: Lock, _ performCriticalSession: () -> Return) -> Return {
   lock.lock()
   defer {

--- a/Sources/Verge/Logger/RuntimeError.swift
+++ b/Sources/Verge/Logger/RuntimeError.swift
@@ -19,22 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
-
-/// A protocol to register logger and get the event VergeStore emits.
-public protocol StoreLogger {
+public enum RuntimeError: Swift.Error {
   
-  func didCommit(log: CommitLog, sender: AnyObject)
-  func didSendActivity(log: ActivityLog, sender: AnyObject)
-
-  func didCreateDispatcher(log: DidCreateDispatcherLog, sender: AnyObject)
-  func didDestroyDispatcher(log: DidDestroyDispatcherLog, sender: AnyObject)
-  
-  func didFind(runtimeError: RuntimeError)
-}
-
-extension StoreLogger {
-  public func didFind(runtimeError: RuntimeError) {
-    
-  }
+  case sinkReceivedOlderVersionIncorrectly(latestState: Any, receivedState: Any)
 }

--- a/Sources/Verge/Logger/RuntimeSanitizer.swift
+++ b/Sources/Verge/Logger/RuntimeSanitizer.swift
@@ -19,7 +19,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-public enum VergeFeatureControl {
+public enum RuntimeSanitizer {
   
   public static var isSanitizerStateReceivingByCorrectOrder: Bool = false
+  
+  public static var onDidFindRuntimeError: (RuntimeError) -> Void = { _ in }
 }

--- a/Sources/Verge/Logger/StoreLogger.swift
+++ b/Sources/Verge/Logger/StoreLogger.swift
@@ -30,11 +30,5 @@ public protocol StoreLogger {
   func didCreateDispatcher(log: DidCreateDispatcherLog, sender: AnyObject)
   func didDestroyDispatcher(log: DidDestroyDispatcherLog, sender: AnyObject)
   
-  func didFind(runtimeError: RuntimeError)
 }
 
-extension StoreLogger {
-  public func didFind(runtimeError: RuntimeError) {
-    
-  }
-}

--- a/Sources/Verge/Store/MutationTrace.swift
+++ b/Sources/Verge/Store/MutationTrace.swift
@@ -29,17 +29,20 @@ public struct MutationTrace: Encodable {
   public let file: StaticString
   public let function: StaticString
   public let line: UInt
+  public let thread: String
 
   public init(
     name: String,
     file: StaticString,
     function: StaticString,
-    line: UInt
+    line: UInt,
+    thread: Thread = .current
   ) {
     self.name = name
     self.file = file
     self.function = function
     self.line = line
+    self.thread = thread.description
   }
 
 }

--- a/Sources/Verge/Store/Store.swift
+++ b/Sources/Verge/Store/Store.swift
@@ -272,7 +272,7 @@ Mutation: (%@)
     var latestStateWrapper: Changes<State>? = nil
         
     /// Firstly, it registers a closure to make sure that it receives all of the updates, even updates inside the first call.
-    let cancellable = _backingStorage.sinkEvent { [logger] (event) in
+    let cancellable = _backingStorage.sinkEvent { (event) in
       switch event {
       case .willUpdate:
         break
@@ -280,7 +280,7 @@ Mutation: (%@)
                 
         sanitizer: do {
           
-          if VergeFeatureControl.isSanitizerStateReceivingByCorrectOrder {
+          if RuntimeSanitizer.isSanitizerStateReceivingByCorrectOrder {
             
             sanitizerQueue.async {
               if let latestState = latestStateWrapper {
@@ -289,8 +289,8 @@ Mutation: (%@)
                   latestStateWrapper = receivedState
                 } else {
                   
-                  logger?.didFind(
-                    runtimeError: .sinkReceivedOlderVersionIncorrectly(
+                  RuntimeSanitizer.onDidFindRuntimeError(
+                    .sinkReceivedOlderVersionIncorrectly(
                       latestState: latestState,
                       receivedState: receivedState
                     )
@@ -349,7 +349,7 @@ Latest Version (%d): (%@)
     if !dropsFirst {
       let value = _backingStorage.value.droppedPrevious()
       
-      if VergeFeatureControl.isSanitizerStateReceivingByCorrectOrder {
+      if RuntimeSanitizer.isSanitizerStateReceivingByCorrectOrder {
         sanitizerQueue.async {
           latestStateWrapper = value
         }

--- a/Sources/Verge/Store/VergeFeatureControls.swift
+++ b/Sources/Verge/Store/VergeFeatureControls.swift
@@ -19,22 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
-
-/// A protocol to register logger and get the event VergeStore emits.
-public protocol StoreLogger {
+public enum VergeFeatureControl {
   
-  func didCommit(log: CommitLog, sender: AnyObject)
-  func didSendActivity(log: ActivityLog, sender: AnyObject)
-
-  func didCreateDispatcher(log: DidCreateDispatcherLog, sender: AnyObject)
-  func didDestroyDispatcher(log: DidDestroyDispatcherLog, sender: AnyObject)
-  
-  func didFind(runtimeError: RuntimeError)
-}
-
-extension StoreLogger {
-  public func didFind(runtimeError: RuntimeError) {
-    
-  }
+  public static var isSanitizerStateReceivingByCorrectOrder: Bool = false
 }

--- a/Tests/VergeORMTests/MultithreadingTests.swift
+++ b/Tests/VergeORMTests/MultithreadingTests.swift
@@ -19,8 +19,13 @@ class MultithreadingTests: XCTestCase {
       
   func testUpdateFromThreads() {
     
+    let exp = expectation(description: "")
+    
+    let g = DispatchGroup()
+    
     for _ in 0..<20 {
       
+      g.enter()
       DispatchQueue.global().async {
         self.store.update { state in
           state.db.performBatchUpdates { (context) in
@@ -31,8 +36,45 @@ class MultithreadingTests: XCTestCase {
             context.entities.author.insert(authors)
           }
         }
+        g.leave()
       }
     }
+    
+    g.notify(queue: .main) {
+      exp.fulfill()
+    }
+    
+    wait(for: [exp], timeout: 10)
                     
+  }
+  
+  
+  func testUpdateFromThreads2() {
+    
+    measure {
+      DispatchQueue.concurrentPerform(iterations: 1000) { (i) in
+        self.store.update { state in
+          state.other.count += 1
+        }
+      }
+    }
+    
+  }
+  
+  func testUpdateFromThreads3() {
+    
+    measure {
+      DispatchQueue.concurrentPerform(iterations: 1000) { (i) in
+        self.store.update { state in
+          state.db.performBatchUpdates { (context) in
+            let authors = (0..<40).map { i in
+              Author(rawID: "author.\(i)")
+            }
+            context.entities.author.insert(authors)
+          }
+        }
+      }
+    }
+    
   }
 }

--- a/Tests/VergeRxTests/ReproduceDeadlockTests.swift
+++ b/Tests/VergeRxTests/ReproduceDeadlockTests.swift
@@ -27,9 +27,7 @@ class ReproduceDeadlockTests: XCTestCase {
   func testReproduceDeadlock() {
     
     let store = StoreWrapper()
-    
-    wait(for: [], timeout: 1)
-    
+        
     _ = store.rx.stateObservable().bind { state in
       if state.count == 1 {
         let group = DispatchGroup()
@@ -45,6 +43,6 @@ class ReproduceDeadlockTests: XCTestCase {
     store.commit {
       $0.count += 1
     }
-            
+              
   }
 }

--- a/Tests/VergeTests/VergeStoreTests.swift
+++ b/Tests/VergeTests/VergeStoreTests.swift
@@ -607,7 +607,7 @@ final class VergeStoreTests: XCTestCase {
       $0.count = 10
     }
 
-    wait(for: [exp], timeout: 1)
+    wait(for: [exp], timeout: 10)
     withExtendedLifetime(cancellable) {}
 
   }

--- a/Tests/VergeTests/VergeStoreTests.swift
+++ b/Tests/VergeTests/VergeStoreTests.swift
@@ -348,6 +348,7 @@ final class VergeStoreTests: XCTestCase {
       $0.markAsModified()
     }
     
+    // stop subscribing
     subscriptions = .init()
 
     store.commit {
@@ -389,7 +390,7 @@ final class VergeStoreTests: XCTestCase {
     }
            
     wait(for: [exp, counter], timeout: 10)
-    XCTAssertEqual(Array((0...1000).map { $0 }), results.value)
+    XCTAssertEqual(Array((0...1000).map { $0 }), results.value, "\(Array((0...1000).map { $0 }).difference(from: results.value))")
     withExtendedLifetime(sub) {}
   }
   

--- a/Tests/VergeTests/VergeStoreTests.swift
+++ b/Tests/VergeTests/VergeStoreTests.swift
@@ -653,16 +653,18 @@ final class VergeStoreTests: XCTestCase {
     
     var bag = Set<VergeAnyCancellable>()
     
-    do {
-      var version: UInt64 = 0
-      store.sinkState(queue: .passthrough) { (s) in
-        if version > s.version {
-          XCTFail()
+    for i in 0..<100 {
+      do {
+        var version: UInt64 = 0
+        store.sinkState(queue: .passthrough) { (s) in
+          if version > s.version {
+            XCTFail()
+          }
+          version = s.version
+          print("\(i)", s.version)
         }
-        version = s.version
-        print("1", s.version)
+        .store(in: &bag)
       }
-      .store(in: &bag)
     }
     
     do {
@@ -672,7 +674,7 @@ final class VergeStoreTests: XCTestCase {
           XCTFail()
         }
         version = s.version
-        print("2", s.version)
+        print("x", s.version)
         store.commit {
           if s.count == 1 {
             $0.count += 1
@@ -681,19 +683,7 @@ final class VergeStoreTests: XCTestCase {
       }
       .store(in: &bag)
     }
-    
-    do {
-      var version: UInt64 = 0
-      store.sinkState(queue: .passthrough) { (s) in
-        if version > s.version {
-          XCTFail()
-        }
-        version = s.version
-        print("3", s.version)
-      }
-      .store(in: &bag)
-    }
-    
+            
     store.commit { (s) in
       s.count += 1
     }

--- a/Verge.xcodeproj/project.pbxproj
+++ b/Verge.xcodeproj/project.pbxproj
@@ -136,6 +136,8 @@
 		4BF21F302458C1860045B5C2 /* UtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF21F2F2458C1860045B5C2 /* UtilTests.swift */; };
 		4BF2BCCE238A658400F70CDA /* VergeClassic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B86A4861F969AD5002D54FE /* VergeClassic.framework */; };
 		4BF3C2EC242093AC006B1726 /* MultithreadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF3C2EA24209324006B1726 /* MultithreadingTests.swift */; };
+		4BF5E10425B0B56D00DB3624 /* RuntimeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF5E10325B0B56D00DB3624 /* RuntimeError.swift */; };
+		4BF5E10E25B0B70400DB3624 /* VergeFeatureControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF5E10D25B0B70400DB3624 /* VergeFeatureControls.swift */; };
 		4BF76681244E1B5300A5EA10 /* Derived.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF76680244E1B5300A5EA10 /* Derived.swift */; };
 		4BF76684244E242A00A5EA10 /* DerivedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF76682244E242500A5EA10 /* DerivedTests.swift */; };
 		4BFF9A792548577500692696 /* InoutRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5D3B2C2544B95100B4DFBE /* InoutRef.swift */; };
@@ -382,6 +384,8 @@
 		4BF470CC23CC36E8001A1D5D /* Edge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Edge.swift; sourceTree = "<group>"; };
 		4BF470CE23CC3949001A1D5D /* CounterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterTests.swift; sourceTree = "<group>"; };
 		4BF470D123CC3A43001A1D5D /* NonAtomicVersionCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAtomicVersionCounter.swift; sourceTree = "<group>"; };
+		4BF5E10325B0B56D00DB3624 /* RuntimeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeError.swift; sourceTree = "<group>"; };
+		4BF5E10D25B0B70400DB3624 /* VergeFeatureControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VergeFeatureControls.swift; sourceTree = "<group>"; };
 		4BF76680244E1B5300A5EA10 /* Derived.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Derived.swift; sourceTree = "<group>"; };
 		4BF76682244E242500A5EA10 /* DerivedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DerivedTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -738,6 +742,7 @@
 		4B91B37E2440C0D8005082D7 /* Store */ = {
 			isa = PBXGroup;
 			children = (
+				4BF5E10D25B0B70400DB3624 /* VergeFeatureControls.swift */,
 				4B427418236F269C00C302C8 /* Store.swift */,
 				4B3834E024823722008A0B47 /* Store+Combine.swift */,
 				4B56AE3E2554EB1B001BA029 /* StoreType+Assignee.swift */,
@@ -771,6 +776,7 @@
 			children = (
 				4B2050F623D5C841000A2779 /* StoreLogger.swift */,
 				4B0AFD6C2388643400AABA90 /* DefaultStoreLogger.swift */,
+				4BF5E10325B0B56D00DB3624 /* RuntimeError.swift */,
 			);
 			path = Logger;
 			sourceTree = "<group>";
@@ -1313,6 +1319,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4BF5E10E25B0B70400DB3624 /* VergeFeatureControls.swift in Sources */,
 				4B04C5632570875200731802 /* Log.swift in Sources */,
 				4B37735324C78F260058A887 /* BackgroundDeallocationQueue.swift in Sources */,
 				4B04C55D2570875200731802 /* Signpost.swift in Sources */,
@@ -1352,6 +1359,7 @@
 				4B1F19C1243A82BC00CED46B /* StateType.swift in Sources */,
 				4B2050F923D5C85B000A2779 /* MutationTrace.swift in Sources */,
 				4B6B77A9243F9E5500E0C0EA /* Comparer.swift in Sources */,
+				4BF5E10425B0B56D00DB3624 /* RuntimeError.swift in Sources */,
 				4B04C55E2570875200731802 /* Storage.swift in Sources */,
 				4BF76681244E1B5300A5EA10 /* Derived.swift in Sources */,
 				4BC4898225A072F400AC0365 /* StoreType+BindingDerived.swift in Sources */,

--- a/Verge.xcodeproj/project.pbxproj
+++ b/Verge.xcodeproj/project.pbxproj
@@ -137,7 +137,7 @@
 		4BF2BCCE238A658400F70CDA /* VergeClassic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B86A4861F969AD5002D54FE /* VergeClassic.framework */; };
 		4BF3C2EC242093AC006B1726 /* MultithreadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF3C2EA24209324006B1726 /* MultithreadingTests.swift */; };
 		4BF5E10425B0B56D00DB3624 /* RuntimeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF5E10325B0B56D00DB3624 /* RuntimeError.swift */; };
-		4BF5E10E25B0B70400DB3624 /* VergeFeatureControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF5E10D25B0B70400DB3624 /* VergeFeatureControls.swift */; };
+		4BF5E10E25B0B70400DB3624 /* RuntimeSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF5E10D25B0B70400DB3624 /* RuntimeSanitizer.swift */; };
 		4BF76681244E1B5300A5EA10 /* Derived.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF76680244E1B5300A5EA10 /* Derived.swift */; };
 		4BF76684244E242A00A5EA10 /* DerivedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF76682244E242500A5EA10 /* DerivedTests.swift */; };
 		4BFF9A792548577500692696 /* InoutRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5D3B2C2544B95100B4DFBE /* InoutRef.swift */; };
@@ -385,7 +385,7 @@
 		4BF470CE23CC3949001A1D5D /* CounterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterTests.swift; sourceTree = "<group>"; };
 		4BF470D123CC3A43001A1D5D /* NonAtomicVersionCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAtomicVersionCounter.swift; sourceTree = "<group>"; };
 		4BF5E10325B0B56D00DB3624 /* RuntimeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeError.swift; sourceTree = "<group>"; };
-		4BF5E10D25B0B70400DB3624 /* VergeFeatureControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VergeFeatureControls.swift; sourceTree = "<group>"; };
+		4BF5E10D25B0B70400DB3624 /* RuntimeSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeSanitizer.swift; sourceTree = "<group>"; };
 		4BF76680244E1B5300A5EA10 /* Derived.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Derived.swift; sourceTree = "<group>"; };
 		4BF76682244E242500A5EA10 /* DerivedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DerivedTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -742,7 +742,6 @@
 		4B91B37E2440C0D8005082D7 /* Store */ = {
 			isa = PBXGroup;
 			children = (
-				4BF5E10D25B0B70400DB3624 /* VergeFeatureControls.swift */,
 				4B427418236F269C00C302C8 /* Store.swift */,
 				4B3834E024823722008A0B47 /* Store+Combine.swift */,
 				4B56AE3E2554EB1B001BA029 /* StoreType+Assignee.swift */,
@@ -777,6 +776,7 @@
 				4B2050F623D5C841000A2779 /* StoreLogger.swift */,
 				4B0AFD6C2388643400AABA90 /* DefaultStoreLogger.swift */,
 				4BF5E10325B0B56D00DB3624 /* RuntimeError.swift */,
+				4BF5E10D25B0B70400DB3624 /* RuntimeSanitizer.swift */,
 			);
 			path = Logger;
 			sourceTree = "<group>";
@@ -1319,7 +1319,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4BF5E10E25B0B70400DB3624 /* VergeFeatureControls.swift in Sources */,
+				4BF5E10E25B0B70400DB3624 /* RuntimeSanitizer.swift in Sources */,
 				4B04C5632570875200731802 /* Log.swift in Sources */,
 				4B37735324C78F260058A887 /* BackgroundDeallocationQueue.swift in Sources */,
 				4B04C55D2570875200731802 /* Signpost.swift in Sources */,

--- a/Verge.xcodeproj/xcshareddata/xcbaselines/4B475BC4239ADE1C008A03E1.xcbaseline/315B1E7C-E080-4CC7-B087-7D7AC32603F2.plist
+++ b/Verge.xcodeproj/xcshareddata/xcbaselines/4B475BC4239ADE1C008A03E1.xcbaseline/315B1E7C-E080-4CC7-B087-7D7AC32603F2.plist
@@ -31,6 +31,19 @@
 				</dict>
 			</dict>
 		</dict>
+		<key>MultithreadingTests</key>
+		<dict>
+			<key>testUpdateFromThreads3()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.106</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
 	</dict>
 </dict>
 </plist>

--- a/Verge.xcodeproj/xcshareddata/xcbaselines/4B475BC4239ADE1C008A03E1.xcbaseline/315B1E7C-E080-4CC7-B087-7D7AC32603F2.plist
+++ b/Verge.xcodeproj/xcshareddata/xcbaselines/4B475BC4239ADE1C008A03E1.xcbaseline/315B1E7C-E080-4CC7-B087-7D7AC32603F2.plist
@@ -18,7 +18,7 @@
 				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.31467</real>
+					<real>0.383</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/Verge.xcodeproj/xcshareddata/xcschemes/LightAll.xcscheme
+++ b/Verge.xcodeproj/xcshareddata/xcschemes/LightAll.xcscheme
@@ -197,11 +197,6 @@
                BlueprintName = "VergeRxTests"
                ReferencedContainer = "container:Verge.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "ReproduceDeadlockTests/testReproduceDeadlock()">
-               </Test>
-            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
Fixes https://github.com/VergeGroup/Verge/issues/221


Fixes:

- Deadlocking by  dispatching commit synchronously inside the sink
- Broken the order of the events by commit recursively inside the sink