### PR TITLE
Introduce Middleware for Store to invoke additional mutation in conjunction with commits - to help reduce the number of commits.

### DIFF
--- a/Docs/docs/store/techniques/store-middleware.md
+++ b/Docs/docs/store/techniques/store-middleware.md
@@ -1,0 +1,28 @@
+---
+id: store-middleware
+title: Middleware in Store
+sidebar_label: Middleware in Store
+---
+
+Middleware can unify extra operations according to dispatched events from `Store`.
+
+Here is exmaple code:
+
+```swift
+let store = DemoStore()
+
+store.add(middleware: .unifiedMutation({ (state, _) in
+  state.count += 1
+}))
+
+/* ✅ */ XCTAssertEqual(store.state.count, 0)
+
+store.commit {
+  $0.count += 1
+}
+
+/* ✅ */ XCTAssertEqual(store.state.count, 2)
+```
+
+In the case of modifying additionally with the updated state, Middleware helps us.  
+This way won't increase the number of commits comparing with using subscribing self and committing.

--- a/Docs/sidebars.js
+++ b/Docs/sidebars.js
@@ -49,6 +49,7 @@ module.exports = {
           label: 'Techniques',
           collapsed: false,
           items: [
+            'store/techniques/store-middleware',
             'store/core/logging',
             'store/techniques/optimization-tips',
             'store/techniques/utilities',

--- a/Sources/Verge/Store/Store.swift
+++ b/Sources/Verge/Store/Store.swift
@@ -265,12 +265,15 @@ Mutation: (%@)
   public var customMirror: Mirror {
     return Mirror(
       self,
-      children: [
-      ],
-      displayStyle: .struct
+      children: KeyValuePairs.init(
+        dictionaryLiteral:
+          ("stateVersion", state.version),
+        ("middlewares", middlewares)
+      ),
+      displayStyle: .class
     )
   }
-
+  
   @inline(__always)
   public func asStore() -> Store<State, Activity> {
     self

--- a/Sources/Verge/Store/Store.swift
+++ b/Sources/Verge/Store/Store.swift
@@ -149,6 +149,16 @@ open class Store<State, Activity>: _VergeObservableObjectBase, CustomReflectable
     super.init()
        
   }
+  
+  /// Registers a middleware.
+  /// MIddleware can execute additional operations unified with mutations.
+  ///
+  public func add(middleware: StoreMiddleware<State>) {
+    // use lock
+    _backingStorage.update { _ in
+      middlewares.append(middleware)
+    }
+  }
 
   /// Receives mutation
   ///
@@ -215,7 +225,7 @@ Mutation: (%@)
         }
         
         self.middlewares.forEach { middleware in
-          middleware._mutate(state: &reference)
+          middleware.mutate(state: &reference, trace: trace)
         }
 
         state = state.makeNextChanges(

--- a/Sources/Verge/Store/Store.swift
+++ b/Sources/Verge/Store/Store.swift
@@ -120,6 +120,8 @@ open class Store<State, Activity>: _VergeObservableObjectBase, CustomReflectable
   
   let name: String
   
+  private var middlewares: [StoreMiddleware<State>] = []
+  
   public private(set) var logger: StoreLogger?
     
   /// An initializer
@@ -210,6 +212,10 @@ Mutation: (%@)
         guard reference.hasModified else {
           // No emits update event
           return .nothingUpdates
+        }
+        
+        self.middlewares.forEach { middleware in
+          middleware._mutate(state: &reference)
         }
 
         state = state.makeNextChanges(

--- a/Sources/Verge/Store/StoreMiddleware.swift
+++ b/Sources/Verge/Store/StoreMiddleware.swift
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2019 muukii
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+open class StoreMiddleware<State> {
+  
+  // TODO: Tantaive
+  open func _mutate(state: inout InoutRef<State>) {
+    
+  }
+  
+}

--- a/Sources/Verge/Store/StoreMiddleware.swift
+++ b/Sources/Verge/Store/StoreMiddleware.swift
@@ -21,18 +21,27 @@
 
 import Foundation
 
+/**
+ Middleware enables us to do extra operations according to dispatched commits in Store.
+ */
 open class StoreMiddleware<State> {
   
   open func mutate(state: inout InoutRef<State>, trace: MutationTrace) {
     
   }
-  
-  public static func makeUnifiedMutation(_ mutate: @escaping (inout InoutRef<State>, _ trace: MutationTrace) -> Void) -> AnonymousStoreMiddleware<State> {
+    
+  /**
+   Creates an instance that commits mutations according to the original committing.
+   */
+  public static func unifiedMutation(_ mutate: @escaping (inout InoutRef<State>, _ trace: MutationTrace) -> Void) -> AnonymousStoreMiddleware<State> {
     return .init(mutate: mutate)
   }
   
 }
 
+/**
+ A closure-based middleware. It enables us to create middleware without creating sub-class.
+ */
 public final class AnonymousStoreMiddleware<State>: StoreMiddleware<State> {
   
   private let _mutate: (inout InoutRef<State>, _ trace: MutationTrace) -> Void

--- a/Sources/Verge/Store/StoreMiddleware.swift
+++ b/Sources/Verge/Store/StoreMiddleware.swift
@@ -23,9 +23,25 @@ import Foundation
 
 open class StoreMiddleware<State> {
   
-  // TODO: Tantaive
-  open func _mutate(state: inout InoutRef<State>) {
+  open func mutate(state: inout InoutRef<State>, trace: MutationTrace) {
     
   }
   
+  public static func makeUnifiedMutation(_ mutate: @escaping (inout InoutRef<State>, _ trace: MutationTrace) -> Void) -> AnonymousStoreMiddleware<State> {
+    return .init(mutate: mutate)
+  }
+  
+}
+
+public final class AnonymousStoreMiddleware<State>: StoreMiddleware<State> {
+  
+  private let _mutate: (inout InoutRef<State>, _ trace: MutationTrace) -> Void
+  
+  public init(mutate: @escaping (inout InoutRef<State>, _ trace: MutationTrace) -> Void) {
+    self._mutate = mutate
+  }
+
+  public override func mutate(state: inout InoutRef<State>, trace: MutationTrace) {
+    _mutate(&state, trace)
+  }
 }

--- a/Tests/VergeTests/StoreMiddlewareTests.swift
+++ b/Tests/VergeTests/StoreMiddlewareTests.swift
@@ -1,0 +1,24 @@
+
+import XCTest
+
+final class StoreMiddlewareTests: XCTestCase {
+    
+  func testCommitHook() {
+        
+    let store = DemoStore()
+    
+    store.add(middleware: .unifiedMutation({ (state, _) in
+      state.count += 1
+    }))
+    
+    XCTAssertEqual(store.state.count, 0)
+    
+    store.commit {
+      $0.count += 1
+    }
+    
+    XCTAssertEqual(store.state.count, 2)
+     
+  }
+  
+}

--- a/Tests/VergeTests/VergeStoreTests.swift
+++ b/Tests/VergeTests/VergeStoreTests.swift
@@ -189,7 +189,7 @@ final class VergeStoreTests: XCTestCase {
   override func tearDown() {
     // Put teardown code here. This method is called after the invocation of each test method in the class.
   }
-
+  
   func testCommit() {
 
     let store = DemoStore()

--- a/Verge.xcodeproj/project.pbxproj
+++ b/Verge.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		4B2050F923D5C85B000A2779 /* MutationTrace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2050F823D5C85B000A2779 /* MutationTrace.swift */; };
 		4B2240A22576431E001BCB93 /* MemoizeMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2240A12576431E001BCB93 /* MemoizeMapTests.swift */; };
 		4B264EF823BD13BC001BD9A0 /* DatabaseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B264EF723BD13BC001BD9A0 /* DatabaseError.swift */; };
+		4B2EAA0F25B224270048C553 /* StoreMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2EAA0E25B224270048C553 /* StoreMiddleware.swift */; };
 		4B35F5752376A692005E6C01 /* SynchronizeDisplayValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B35F5742376A692005E6C01 /* SynchronizeDisplayValueTests.swift */; };
 		4B37735324C78F260058A887 /* BackgroundDeallocationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B37735224C78F260058A887 /* BackgroundDeallocationQueue.swift */; };
 		4B3834DD2482330C008A0B47 /* StateReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3834DC2482330C008A0B47 /* StateReader.swift */; };
@@ -261,6 +262,7 @@
 		4B2050F823D5C85B000A2779 /* MutationTrace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationTrace.swift; sourceTree = "<group>"; };
 		4B2240A12576431E001BCB93 /* MemoizeMapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoizeMapTests.swift; sourceTree = "<group>"; };
 		4B264EF723BD13BC001BD9A0 /* DatabaseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseError.swift; sourceTree = "<group>"; };
+		4B2EAA0E25B224270048C553 /* StoreMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreMiddleware.swift; sourceTree = "<group>"; };
 		4B2F001D2459DC4A0034DA40 /* All.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = All.xctestplan; path = /Users/muukii/.ghq/github.com/muukii/Verge/worktree/space1/Tests/All.xctestplan; sourceTree = "<absolute>"; };
 		4B35F5742376A692005E6C01 /* SynchronizeDisplayValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizeDisplayValueTests.swift; sourceTree = "<group>"; };
 		4B37735224C78F260058A887 /* BackgroundDeallocationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundDeallocationQueue.swift; sourceTree = "<group>"; };
@@ -743,6 +745,7 @@
 			isa = PBXGroup;
 			children = (
 				4B427418236F269C00C302C8 /* Store.swift */,
+				4B2EAA0E25B224270048C553 /* StoreMiddleware.swift */,
 				4B3834E024823722008A0B47 /* Store+Combine.swift */,
 				4B56AE3E2554EB1B001BA029 /* StoreType+Assignee.swift */,
 				4BC4896525A06B0D00AC0365 /* StoreType+Derived.swift */,
@@ -1358,6 +1361,7 @@
 				4B3834E124823722008A0B47 /* Store+Combine.swift in Sources */,
 				4B1F19C1243A82BC00CED46B /* StateType.swift in Sources */,
 				4B2050F923D5C85B000A2779 /* MutationTrace.swift in Sources */,
+				4B2EAA0F25B224270048C553 /* StoreMiddleware.swift in Sources */,
 				4B6B77A9243F9E5500E0C0EA /* Comparer.swift in Sources */,
 				4BF5E10425B0B56D00DB3624 /* RuntimeError.swift in Sources */,
 				4B04C55E2570875200731802 /* Storage.swift in Sources */,

--- a/Verge.xcodeproj/project.pbxproj
+++ b/Verge.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		4B6F6F3924521F1E00B6CC3A /* Edge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF470CC23CC36E8001A1D5D /* Edge.swift */; };
 		4B6F6F3A24521F1E00B6CC3A /* NonAtomicVersionCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF470D123CC3A43001A1D5D /* NonAtomicVersionCounter.swift */; };
 		4B6F6F3B24521F2B00B6CC3A /* CounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF470CE23CC3949001A1D5D /* CounterTests.swift */; };
+		4B70306825C46A78005C7677 /* StoreMiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B70306725C46A78005C7677 /* StoreMiddlewareTests.swift */; };
 		4B71CEEE23B14394004520CE /* ActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B71CEED23B14394004520CE /* ActivityTests.swift */; };
 		4B779B522535A03100EE708B /* KeyPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B779B512535A03100EE708B /* KeyPathTests.swift */; };
 		4B786324233912AB009B9C1B /* VergeStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B786322233912AB009B9C1B /* VergeStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -308,6 +309,7 @@
 		4B6B77AA243FA3EB00E0C0EA /* _StateTypeContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = _StateTypeContainer.swift; sourceTree = "<group>"; };
 		4B6BF62923AD7B55001E5361 /* CollectionPerformance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionPerformance.swift; sourceTree = "<group>"; };
 		4B6E360F23A7ED1900EB490C /* IndexType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexType.swift; sourceTree = "<group>"; };
+		4B70306725C46A78005C7677 /* StoreMiddlewareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreMiddlewareTests.swift; sourceTree = "<group>"; };
 		4B71CEED23B14394004520CE /* ActivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityTests.swift; sourceTree = "<group>"; };
 		4B73F08824041811006910E6 /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		4B779B512535A03100EE708B /* KeyPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPathTests.swift; sourceTree = "<group>"; };
@@ -658,6 +660,7 @@
 				4B2240A12576431E001BCB93 /* MemoizeMapTests.swift */,
 				4B654BF025869A3300F5AEA4 /* EdgeTests.swift */,
 				4BC489A325A07A9700AC0365 /* KeyPathIdentifierStoreTests.swift */,
+				4B70306725C46A78005C7677 /* StoreMiddlewareTests.swift */,
 			);
 			path = VergeTests;
 			sourceTree = "<group>";
@@ -1295,6 +1298,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4B70306825C46A78005C7677 /* StoreMiddlewareTests.swift in Sources */,
 				4B95BE5A244F10F200124F6B /* DemoState.swift in Sources */,
 				4B04C4FC257086D900731802 /* EventEmitterTests.swift in Sources */,
 				4B9DD6B924CB6B0C0062FB7A /* CachedMapTests.swift in Sources */,


### PR DESCRIPTION
```swift
let store = DemoStore()

store.add(middleware: .unifiedMutation({ (state, _) in
  state.count += 1
}))

/* ✅ */ XCTAssertEqual(store.state.count, 0)

store.commit {
  $0.count += 1
}

/* ✅ */ XCTAssertEqual(store.state.count, 2)
```


## Related

https://github.com/VergeGroup/Verge/pull/222