### PR TITLE
Add a special method that reads value with pointer

### DIFF
--- a/Sources/Verge/Library/InoutRef.swift
+++ b/Sources/Verge/Library/InoutRef.swift
@@ -236,7 +236,6 @@ public final class InoutRef<Wrapped> {
 
 }
 
-#if false
 /// Do not retain on anywhere.
 @dynamicMemberLookup
 public final class ReadRef<Wrapped> {
@@ -312,4 +311,3 @@ public final class ReadRef<Wrapped> {
   }
 
 }
-#endif

--- a/Sources/VergeORM/Derived+ORM.swift
+++ b/Sources/VergeORM/Derived+ORM.swift
@@ -131,6 +131,8 @@ extension Pipeline where Input : ChangesType, Input.Value : DatabaseEmbedding {
                 
         let hasChanges = state.asChanges().hasChanges(
           { (composing) -> Input.Value.Database in
+            // TODO: causing copy in some-cases
+            // `initializeWithCopy`
             let db = path(composing.root)
             return db
         }, noChangesComparer


### PR DESCRIPTION
```swift
let state: Changes<State> 

state._read { (ref: ReadRef<State>)  in 
  ref.map(\.body) { body in 
    checkA(body)
    checkB(body)
    checkC(body)
  }
 }
```

Instead of:

```swift
let state: Changes<State> 

let body = state.body
checkA(body)
checkB(body)
checkC(body)
```

Reading the value with reducing the possibility of the happening copy.