### PR TITLE
Make Derived debuggable

### DIFF
--- a/Sources/Verge/Derived/Derived.swift
+++ b/Sources/Verge/Derived/Derived.swift
@@ -118,25 +118,22 @@ public class Derived<Value>: _VergeObservableObjectBase, DerivedType {
     get: Pipeline<UpstreamState, Value>,
     set: ((Value) -> Void)?,
     initialUpstreamState: UpstreamState,
-    subscribeUpstreamState: (@escaping (UpstreamState, MutationTrace?) -> Void) -> CancellableType,
+    subscribeUpstreamState: (@escaping (UpstreamState) -> Void) -> CancellableType,
     retainsUpstream: Any?
   ) {
     
     let store = Store<Value, Never>.init(initialState: get.makeInitial(initialUpstreamState), logger: nil)
                      
-    let s = subscribeUpstreamState { [weak store] value, mutationTrace in
+    let s = subscribeUpstreamState { [weak store] value in
       let update = get.makeResult(value)
       switch update {
       case .noUpdates:
         break
       case .new(let newState):
         // TODO: Take over state.modification & state.mutation
-        store?._commit(
-          trace: mutationTrace ?? .init(),
-          mutation: {
-            $0.replace(with: newState)
-          }
-        )
+        store?.commit {
+          $0.replace(with: newState)
+        }
       }
     }
     
@@ -144,6 +141,46 @@ public class Derived<Value>: _VergeObservableObjectBase, DerivedType {
     self.subscription = VergeAnyCancellable.init(s)
     self._set = set
     self.innerStore = store
+  }
+  
+  /// Low-level initializer
+  /// - Parameters:
+  ///   - get: MemoizeMap to make a `Value` from `UpstreamState`
+  ///   - set: A closure to apply new-value to `UpstreamState`, it will need in creating `BindingDerived`.
+  ///   - initialUpstreamState: Initial value of the `UpstreamState`
+  ///   - subscribeUpstreamState: Starts subscribe updates of the `UpstreamState`
+  ///   - retainsUpstream: Any instances to retain in this instance.
+  public init<UpstreamState: HasTraces>(
+    get: Pipeline<UpstreamState, Value>,
+    set: ((Value) -> Void)?,
+    initialUpstreamState: UpstreamState,
+    subscribeUpstreamState: (@escaping (UpstreamState) -> Void) -> CancellableType,
+    retainsUpstream: Any?
+  ) {
+  
+    let innerStore = Store<Value, Never>.init(initialState: get.makeInitial(initialUpstreamState), logger: nil)
+        
+    let pointer = Unmanaged.passUnretained(innerStore).toOpaque()
+    
+    let s = subscribeUpstreamState { [weak innerStore] value in
+      let update = get.makeResult(value)
+      switch update {
+      case .noUpdates:
+        break
+      case .new(let newState):
+        // TODO: Take over state.modification & state.mutation
+        innerStore?.commit("Derived<InnerStore:\(pointer)>") {
+          $0.append(traces: value.traces)
+          $0.replace(with: newState)
+        }
+      }
+    }
+    
+    self.retainsUpstream = retainsUpstream
+    self.subscription = VergeAnyCancellable(s)
+    self._set = set
+    self.innerStore = innerStore
+    
   }
 
   deinit {

--- a/Sources/Verge/Library/InoutRef.swift
+++ b/Sources/Verge/Library/InoutRef.swift
@@ -45,6 +45,8 @@ public final class InoutRef<Wrapped> {
   }
 
   // MARK: - Properties
+  
+  public private(set) var traces: [MutationTrace] = []
 
   public var modification: Modification? {
 
@@ -92,6 +94,14 @@ public final class InoutRef<Wrapped> {
   }
 
   // MARK: - Functions
+  
+  func append(trace: MutationTrace) {
+    traces.append(trace)
+  }
+  
+  func append(traces otherTraces: [MutationTrace]) {
+    traces.append(contentsOf: otherTraces)
+  }
 
   public subscript<T> (dynamicMember keyPath: WritableKeyPath<Wrapped, T>) -> T {
     _read {

--- a/Sources/Verge/Logger/DefaultStoreLogger.swift
+++ b/Sources/Verge/Logger/DefaultStoreLogger.swift
@@ -27,14 +27,14 @@ public struct CommitLog: Encodable {
   
   public let type: String = "commit"
   public let tookMilliseconds: Double
-  public let trace: MutationTrace
+  public let traces: [MutationTrace]
   public let store: String
 
   @inlinable
-  public init(storeName: String, trace: MutationTrace, time: CFTimeInterval) {
+  public init(storeName: String, traces: [MutationTrace], time: CFTimeInterval) {
     self.store = storeName
     self.tookMilliseconds = time * 1000
-    self.trace = trace
+    self.traces = traces
   }
 }
 

--- a/Sources/Verge/Store/DispatcherType.swift
+++ b/Sources/Verge/Store/DispatcherType.swift
@@ -130,10 +130,10 @@ extension DispatcherType {
     return try store.asStore()._receive(
       mutation: { state -> Result in
         try state.map(keyPath: scope) { (ref: inout InoutRef<Scope>) -> Result in
-          try mutation(&ref)
+          ref.append(trace: trace)
+          return try mutation(&ref)
         }
-      },
-      trace: trace
+      }
     )
   }
   
@@ -146,10 +146,10 @@ extension DispatcherType {
     mutation: (inout InoutRef<Scope>) throws -> Result
   ) rethrows -> Result where Scope == WrappedStore.State {
     return try store.asStore()._receive(
-      mutation: { state -> Result in
-        try mutation(&state)
-      },
-      trace: trace
+      mutation: { ref -> Result in
+        ref.append(trace: trace)
+        return try mutation(&ref)
+      }
     )
   }
 
@@ -193,10 +193,10 @@ extension DispatcherType {
     return try store.asStore()._receive(
       mutation: { state -> Result in
         try state.map(keyPath: scope) { (ref: inout InoutRef<NewScope>) -> Result in
-          try mutation(&ref)
+          ref.append(trace: trace)
+          return try mutation(&ref)
         }
-      },
-      trace: trace
+      }
     )
   }
 
@@ -221,10 +221,10 @@ extension DispatcherType {
     return try store.asStore()._receive(
       mutation: { state -> Result in
         try state.map(keyPath: scope) { (ref: inout InoutRef<NewScope>?) -> Result in
-          try mutation(&ref)
+          ref?.append(trace: trace)
+          return try mutation(&ref)
         }
-      },
-      trace: trace
+      }
     )
   }
 

--- a/Sources/Verge/Store/DispatcherType.swift
+++ b/Sources/Verge/Store/DispatcherType.swift
@@ -136,6 +136,22 @@ extension DispatcherType {
       trace: trace
     )
   }
+  
+  /// Run Mutation that created inline
+  ///
+  /// Throwable
+  @inline(__always)
+  func _commit<Result>(
+    trace: MutationTrace,
+    mutation: (inout InoutRef<Scope>) throws -> Result
+  ) rethrows -> Result where Scope == WrappedStore.State {
+    return try store.asStore()._receive(
+      mutation: { state -> Result in
+        try mutation(&state)
+      },
+      trace: trace
+    )
+  }
 
   /// Run Mutation that created inline
   ///
@@ -153,13 +169,7 @@ extension DispatcherType {
       function: function,
       line: line
     )
-
-    return try store.asStore()._receive(
-      mutation: { state -> Result in
-        try mutation(&state)
-      },
-      trace: trace
-    )
+    return try self._commit(trace: trace, mutation: mutation)
   }
 
   /// Run Mutation that created inline

--- a/Sources/Verge/Store/MutationTrace.swift
+++ b/Sources/Verge/Store/MutationTrace.swift
@@ -21,8 +21,21 @@
 
 import Foundation
 
+public protocol HasTraces {
+  var traces: [MutationTrace] { get }
+}
+
 /// A trace that indicates the mutation where comes from.
-public struct MutationTrace: Encodable {
+public struct MutationTrace: Encodable, Equatable {
+  
+  public static func == (lhs: MutationTrace, rhs: MutationTrace) -> Bool {
+    lhs.createdAt == rhs.createdAt &&
+      lhs.name == rhs.name &&
+      lhs.file.description == rhs.file.description &&
+      lhs.function.description == rhs.function.description &&
+      lhs.line == rhs.line &&
+      lhs.thread == rhs.thread
+  }
 
   public let createdAt: Date = .init()
   public let name: String

--- a/Sources/Verge/Store/MutationTrace.swift
+++ b/Sources/Verge/Store/MutationTrace.swift
@@ -32,10 +32,10 @@ public struct MutationTrace: Encodable {
   public let thread: String
 
   public init(
-    name: String,
-    file: StaticString,
-    function: StaticString,
-    line: UInt,
+    name: String = "",
+    file: StaticString = #file,
+    function: StaticString = #function,
+    line: UInt = #line,
     thread: Thread = .current
   ) {
     self.name = name

--- a/Sources/Verge/Store/StoreMiddleware.swift
+++ b/Sources/Verge/Store/StoreMiddleware.swift
@@ -26,14 +26,14 @@ import Foundation
  */
 open class StoreMiddleware<State> {
   
-  open func mutate(state: inout InoutRef<State>, trace: MutationTrace) {
+  open func mutate(state: inout InoutRef<State>) {
     
   }
     
   /**
    Creates an instance that commits mutations according to the original committing.
    */
-  public static func unifiedMutation(_ mutate: @escaping (inout InoutRef<State>, _ trace: MutationTrace) -> Void) -> AnonymousStoreMiddleware<State> {
+  public static func unifiedMutation(_ mutate: @escaping (inout InoutRef<State>) -> Void) -> AnonymousStoreMiddleware<State> {
     return .init(mutate: mutate)
   }
   
@@ -44,13 +44,13 @@ open class StoreMiddleware<State> {
  */
 public final class AnonymousStoreMiddleware<State>: StoreMiddleware<State> {
   
-  private let _mutate: (inout InoutRef<State>, _ trace: MutationTrace) -> Void
+  private let _mutate: (inout InoutRef<State>) -> Void
   
-  public init(mutate: @escaping (inout InoutRef<State>, _ trace: MutationTrace) -> Void) {
+  public init(mutate: @escaping (inout InoutRef<State>) -> Void) {
     self._mutate = mutate
   }
 
-  public override func mutate(state: inout InoutRef<State>, trace: MutationTrace) {
-    _mutate(&state, trace)
+  public override func mutate(state: inout InoutRef<State>) {
+    _mutate(&state)
   }
 }

--- a/Sources/VergeRx/Store+Rx.swift
+++ b/Sources/VergeRx/Store+Rx.swift
@@ -109,7 +109,7 @@ extension ObservableType {
       if pre == nil {
         pre = Changes<Element>.init(old: nil, new: element)
       } else {
-        pre = pre!.makeNextChanges(with: element, from: trace, modification: .indeterminate)
+        pre = pre!.makeNextChanges(with: element, from: [trace], modification: .indeterminate)
       }
     })
     .map { $0! }

--- a/Tests/VergeTests/MutationTraceTests.swift
+++ b/Tests/VergeTests/MutationTraceTests.swift
@@ -1,0 +1,39 @@
+
+import XCTest
+
+import Verge
+
+final class MutationTraceTests: XCTestCase {
+  
+  func testOneCommit() {
+    
+    let store = DemoStore()
+    
+    store.commit("MyCommit") {
+      $0.count += 1
+    }
+    
+    let state = store.state
+    
+    XCTAssertEqual(state.traces.count, 1)
+    XCTAssertEqual(state.traces.first!.name, "MyCommit")
+  }
+  
+  func testDerived() {
+    
+    let store = DemoStore()
+    
+    let derived = store
+      .derived(.map(\.count), queue: .passthrough)
+    
+    store.commit("From_Store") {
+      $0.count += 1
+    }
+    
+    let value = derived.value
+    
+    XCTAssertEqual(value.traces.count, 3)
+    
+  }
+  
+}

--- a/Tests/VergeTests/StoreMiddlewareTests.swift
+++ b/Tests/VergeTests/StoreMiddlewareTests.swift
@@ -7,7 +7,7 @@ final class StoreMiddlewareTests: XCTestCase {
         
     let store = DemoStore()
     
-    store.add(middleware: .unifiedMutation({ (state, _) in
+    store.add(middleware: .unifiedMutation({ (state) in
       state.count += 1
     }))
     

--- a/Verge.xcodeproj/project.pbxproj
+++ b/Verge.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		4B786324233912AB009B9C1B /* VergeStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B786322233912AB009B9C1B /* VergeStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4B7A71D024874A8900A116F7 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7A71CF24874A8900A116F7 /* PerformanceTests.swift */; };
 		4B7A71D22487532D00A116F7 /* _COWFragmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7A71D12487532D00A116F7 /* _COWFragmentTests.swift */; };
+		4B7F275625CFC59C0058BC69 /* MutationTraceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B7F275525CFC59C0058BC69 /* MutationTraceTests.swift */; };
 		4B8035FB244CB96B0028BD32 /* MigrationFromClassicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B8035FA244CB96B0028BD32 /* MigrationFromClassicTests.swift */; };
 		4B8035FC244CB9900028BD32 /* VergeClassic.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B86A4861F969AD5002D54FE /* VergeClassic.framework */; };
 		4B80B74323F92B3D000BCFB2 /* HashIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B80B74223F92B3D000BCFB2 /* HashIndexTests.swift */; };
@@ -318,6 +319,7 @@
 		4B786323233912AB009B9C1B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4B7A71CF24874A8900A116F7 /* PerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
 		4B7A71D12487532D00A116F7 /* _COWFragmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _COWFragmentTests.swift; sourceTree = "<group>"; };
+		4B7F275525CFC59C0058BC69 /* MutationTraceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationTraceTests.swift; sourceTree = "<group>"; };
 		4B7F385123895B24000B9ACF /* Store+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Store+Rx.swift"; sourceTree = "<group>"; };
 		4B8035FA244CB96B0028BD32 /* MigrationFromClassicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationFromClassicTests.swift; sourceTree = "<group>"; };
 		4B80B74223F92B3D000BCFB2 /* HashIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashIndexTests.swift; sourceTree = "<group>"; };
@@ -661,6 +663,7 @@
 				4B654BF025869A3300F5AEA4 /* EdgeTests.swift */,
 				4BC489A325A07A9700AC0365 /* KeyPathIdentifierStoreTests.swift */,
 				4B70306725C46A78005C7677 /* StoreMiddlewareTests.swift */,
+				4B7F275525CFC59C0058BC69 /* MutationTraceTests.swift */,
 			);
 			path = VergeTests;
 			sourceTree = "<group>";
@@ -1312,6 +1315,7 @@
 				4B86D826244A2A1D008D3040 /* Sample.swift in Sources */,
 				4BFF9A85254857AC00692696 /* InoutRefTests.swift in Sources */,
 				4B1F19C4243A88A000CED46B /* ComputedTests.swift in Sources */,
+				4B7F275625CFC59C0058BC69 /* MutationTraceTests.swift in Sources */,
 				4B71CEEE23B14394004520CE /* ActivityTests.swift in Sources */,
 				4B35F5752376A692005E6C01 /* SynchronizeDisplayValueTests.swift in Sources */,
 				4B7A71D22487532D00A116F7 /* _COWFragmentTests.swift in Sources */,


### PR DESCRIPTION
The changes object which from Derived does not have actual MutationTrace.

Now we can detect the value how changed over derived and chaining from store's commit.