### PR TITLE
[Beta] Changes supports map with optional keypath

### DIFF
--- a/Sources/Verge/Store/Changes.swift
+++ b/Sources/Verge/Store/Changes.swift
@@ -193,7 +193,7 @@ public final class Changes<Value>: ChangesType, Equatable, HasTraces {
       yield primitive[keyPath: keyPath]
     }
   }
-
+  
   /// Returns a new instance that projects value by transform closure.
   ///
   /// - Warning: modification would be dropped.
@@ -210,6 +210,22 @@ public final class Changes<Value>: ChangesType, Equatable, HasTraces {
       traces: traces,
       modification: nil
     )
+  }
+  
+  public func _beta_map<U>(_ keyPath: KeyPath<Value, U?>) -> Changes<U>? {
+    
+    guard self[dynamicMember: keyPath] != nil else {
+      return nil
+    }
+           
+    return Changes<U>(
+      previous: previous.flatMap { $0._beta_map(keyPath) },
+      innerBox: innerBox.map { $0[keyPath: keyPath]! },
+      version: version,
+      traces: traces,
+      modification: nil
+    )
+    
   }
 
   public func makeNextChanges(
@@ -522,7 +538,7 @@ extension Changes {
         cachedComputedValueStorage: cachedComputedValueStorage
       )
     }
-    
+     
     @inline(__always)
     func _read(perform: (ReadRef<Value>) -> Void) {
       withUnsafePointer(to: &value) { (pointer) -> Void in

--- a/Tests/VergeTests/VergeStoreTests.swift
+++ b/Tests/VergeTests/VergeStoreTests.swift
@@ -547,5 +547,54 @@ final class VergeStoreTests: XCTestCase {
     XCTAssertEqual(store1.state.version, 0)
 
   }
+  
+  func testChangesBetaMap() {
+    
+    let store = Store()
+    
+    XCTAssert(store.state.nested != nil)
+    
+    do {
+      
+      let state = store.state
+      
+      if let _ = state._beta_map(\.optionalNested) {
+        XCTFail()
+      }
+      
+    }
+    
+    store.commit {
+      $0.optionalNested = .init()
+    }
+    
+    do {
+      
+      let state = store.state
+      
+      if let nested = state._beta_map(\.optionalNested) {
+        XCTAssert(nested.previous == nil)
+      } else {
+        XCTFail()
+      }
+      
+    }
+    
+    store.commit {
+      $0.optionalNested!.myName = "hello"
+    }
+    
+    do {
+      
+      let state = store.state
+      
+      if let nested = state._beta_map(\.optionalNested) {
+        XCTAssert(nested.previous != nil)
+      } else {
+        XCTFail()
+      }
+      
+    }
+  }
 
 }

--- a/Tests/VergeTests/VergeStoreTests.swift
+++ b/Tests/VergeTests/VergeStoreTests.swift
@@ -552,7 +552,7 @@ final class VergeStoreTests: XCTestCase {
     
     let store = Store()
     
-    XCTAssert(store.state.optionalNested != nil)
+    XCTAssert(store.state.optionalNested == nil)
     
     do {
       

--- a/Tests/VergeTests/VergeStoreTests.swift
+++ b/Tests/VergeTests/VergeStoreTests.swift
@@ -552,7 +552,7 @@ final class VergeStoreTests: XCTestCase {
     
     let store = Store()
     
-    XCTAssert(store.state.nested != nil)
+    XCTAssert(store.state.optionalNested != nil)
     
     do {
       


### PR DESCRIPTION
```swift
struct State {
  var nested: Nested?
}
```

Current:
```
let state: Changes<State>
let nested: Changes<Nested?> = state.map(\.nested)
```

Now:
```
let state: Changes<State>
let nested: Changes<Nested>? = state._beta_map(\.nested)
```

we need to get better name
