### PR TITLE
[Experimental] Add SwiftUI.Binding support

### DIFF
--- a/Sources/Verge/Store/StoreType+SwiftUI.swift
+++ b/Sources/Verge/Store/StoreType+SwiftUI.swift
@@ -72,4 +72,22 @@ extension StoreType {
   }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+extension StoreComponentType {
+  /// Calls the function of the same name defined in StoreType.
+  /// Usage:
+  ///
+  ///     TextField("hoge", text: store.binding(\.inputingText))
+  ///
+  /// - Warning: Still in experimentals.
+  /// - Parameters:
+  ///   - keypath: A property of the state to be bound.
+  ///   - mutation: A closure to update the state.
+  ///   If the closure is nil, state will be automatically updated.
+  /// - Returns: The result of binding
+  public func binding<T>(_ keypath: WritableKeyPath<Self.WrappedStore.State, T>, with mutation: ((T) -> Void)? = nil) -> Binding<T> {
+    store.binding(keypath, with: mutation)
+  }
+}
+
 #endif

--- a/Sources/Verge/Store/StoreType+SwiftUI.swift
+++ b/Sources/Verge/Store/StoreType+SwiftUI.swift
@@ -54,7 +54,7 @@ extension StoreType {
     ///   - mutation: A closure to update the state.
     ///   If the closure is nil, state will be automatically updated.
     /// - Returns: The result of binding
-    func binding<T>(_ keypath: WritableKeyPath<State, T>, with mutation: ((T) -> Void)? = nil) -> Binding<T> {
+    public func binding<T>(_ keypath: WritableKeyPath<State, T>, with mutation: ((T) -> Void)? = nil) -> Binding<T> {
         .init(get: { [weak self] in
             guard let self = self else {
                 fatalError("The Store should be retained by the view until the view is released.")

--- a/Sources/Verge/Store/StoreType+SwiftUI.swift
+++ b/Sources/Verge/Store/StoreType+SwiftUI.swift
@@ -48,7 +48,7 @@ extension StoreType {
     ///
     ///     TextField("hoge", text: store.binding(\.inputingText))
     ///
-    /// - Warning: The returned string is not localized.
+    /// - Warning: Still in experimentals.
     /// - Parameters:
     ///   - keypath: A property of the state to be bound.
     ///   - mutation: A closure to update the state.

--- a/Sources/Verge/Store/StoreType+SwiftUI.swift
+++ b/Sources/Verge/Store/StoreType+SwiftUI.swift
@@ -43,33 +43,33 @@ extension BindingDerived {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 extension StoreType {
-    /// Generates a SwiftUI.Binding that gets and updates the StoreType.State.
-    /// Usage:
-    ///
-    ///     TextField("hoge", text: store.binding(\.inputingText))
-    ///
-    /// - Warning: Still in experimentals.
-    /// - Parameters:
-    ///   - keypath: A property of the state to be bound.
-    ///   - mutation: A closure to update the state.
-    ///   If the closure is nil, state will be automatically updated.
-    /// - Returns: The result of binding
-    public func binding<T>(_ keypath: WritableKeyPath<State, T>, with mutation: ((T) -> Void)? = nil) -> Binding<T> {
-        .init(get: { [weak self] in
-            guard let self = self else {
-                fatalError("The Store should be retained by the view until the view is released.")
-            }
-            return self.primitiveState[keyPath: keypath]
-        }, set: { [weak self] value in
-            if let mutation = mutation {
-                mutation(value)
-            } else {
-                self?.asStore().commit {
-                    $0[keyPath: keypath] = value
-                }
-            }
-        })
-    }
+  /// Generates a SwiftUI.Binding that gets and updates the StoreType.State.
+  /// Usage:
+  ///
+  ///     TextField("hoge", text: store.binding(\.inputingText))
+  ///
+  /// - Warning: Still in experimentals.
+  /// - Parameters:
+  ///   - keypath: A property of the state to be bound.
+  ///   - mutation: A closure to update the state.
+  ///   If the closure is nil, state will be automatically updated.
+  /// - Returns: The result of binding
+  public func binding<T>(_ keypath: WritableKeyPath<State, T>, with mutation: ((T) -> Void)? = nil) -> Binding<T> {
+    .init(get: { [weak self] in
+      guard let self = self else {
+        fatalError("The Store should be retained by the view until the view is released.")
+      }
+      return self.primitiveState[keyPath: keypath]
+    }, set: { [weak self] value in
+      if let mutation = mutation {
+        mutation(value)
+      } else {
+        self?.asStore().commit {
+          $0[keyPath: keypath] = value
+        }
+      }
+    })
+  }
 }
 
 #endif

--- a/Sources/Verge/Store/StoreType+SwiftUI.swift
+++ b/Sources/Verge/Store/StoreType+SwiftUI.swift
@@ -43,6 +43,17 @@ extension BindingDerived {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 extension StoreType {
+    /// Generates a SwiftUI.Binding that gets and updates the StoreType.State.
+    /// Usage:
+    ///
+    ///     TextField("hoge", text: store.binding(\.inputingText))
+    ///
+    /// - Warning: The returned string is not localized.
+    /// - Parameters:
+    ///   - keypath: A property of the state to be bound.
+    ///   - mutation: A closure to update the state.
+    ///   If the closure is nil, state will be automatically updated.
+    /// - Returns: The result of binding
     func binding<T>(_ keypath: WritableKeyPath<State, T>, with mutation: ((T) -> Void)? = nil) -> Binding<T> {
         .init(get: { [weak self] in
             guard let self = self else {

--- a/Sources/Verge/Store/StoreType+SwiftUI.swift
+++ b/Sources/Verge/Store/StoreType+SwiftUI.swift
@@ -41,4 +41,24 @@ extension BindingDerived {
   }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+extension StoreType {
+    func binding<T>(_ keypath: WritableKeyPath<State, T>, with mutation: ((T) -> Void)? = nil) -> Binding<T> {
+        .init(get: { [weak self] in
+            guard let self = self else {
+                fatalError("The Store should be retained by the view until the view is released.")
+            }
+            return self.primitiveState[keyPath: keypath]
+        }, set: { [weak self] value in
+            if let mutation = mutation {
+                mutation(value)
+            } else {
+                self?.asStore().commit {
+                    $0[keyPath: keypath] = value
+                }
+            }
+        })
+    }
+}
+
 #endif

--- a/Tests/VergeTests/VergeStoreTests.swift
+++ b/Tests/VergeTests/VergeStoreTests.swift
@@ -597,4 +597,17 @@ final class VergeStoreTests: XCTestCase {
     }
   }
 
+  func testChangesSwiftUIBinding() {
+    let store = Store()
+    let binding = store.binding(\.count)
+
+    binding.wrappedValue = 5
+    XCTAssertEqual(store.state.count, 5)
+
+    store.commit {
+      $0.count = 10
+    }
+    XCTAssertEqual(binding.wrappedValue, 10)
+  }
+
 }


### PR DESCRIPTION
### Motivation and Context
Most of the views that simply receive the state and reflect it in its appearance only need to get the state through a StateReader.
However, a View that updates its state, such as a TextField, needs to generate a SwiftUI.Binding.
I want to hide the generation process.

### Description
StoreType provides a function that returns SwiftUI.Binding.